### PR TITLE
support for OPT as code

### DIFF
--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -165,7 +165,7 @@ describe("Parser Tests", function () {
             expect(asmLine.data).to.be.equal("#mempos,d1");
             expect(asmLine.comment).to.be.empty;
         });
-        it("Should parse compiler optios as instruction", function () {
+        it("Should parse compiler option as instruction", function () {
             let asmLine = new ASMLine("\t\tOPT O+,OW-,OW1+,OW6+,P=68000    ; mycomment");
             expect(asmLine.label).to.be.empty;
             expect(asmLine.instruction).to.be.equal("OPT");

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -165,6 +165,13 @@ describe("Parser Tests", function () {
             expect(asmLine.data).to.be.equal("#mempos,d1");
             expect(asmLine.comment).to.be.empty;
         });
+        it("Should parse compiler optios as instruction", function () {
+            let asmLine = new ASMLine("\t\tOPT O+,OW-,OW1+,OW6+,P=68000    ; mycomment");
+            expect(asmLine.label).to.be.empty;
+            expect(asmLine.instruction).to.be.equal("OPT");
+            expect(asmLine.data).to.be.equal("O+,OW-,OW1+,OW6+,P=68000");
+            expect(asmLine.comment).to.be.equal("; mycomment");
+        });
     });
     context("Hover instruction file parsing", function () {
         it("Should read the file correctly", function () {

--- a/syntaxes/M68k-Assembly.YAML-tmLanguage
+++ b/syntaxes/M68k-Assembly.YAML-tmLanguage
@@ -123,7 +123,7 @@ patterns:
   match: (?i)\b(if(eq|ne|gt|ge|lt|le|b|nb|c|nc|d|nd|macrod|macrond)|else|end|endif)\b
 
 - name: keyword.control.other.m68k
-  match: (?i)\b(align|cargs|clrfo|clrso|cnop|comm|comment|echo|einline|end[cmfpr]?|erem|even|fail|fpu|idnt|inline|jumpptr|list|llen|load|machine|mexit|mmu|nolist|nopage|nref|odd|offset|opword|org|output|page|plen|print[tv]|public|record|rem|rept|rorg|rsreset|rsset|set|setfo|setso|spc|text|ttl|weak|xdef|xref)\b
+  match: (?i)\b(opt|align|cargs|clrfo|clrso|cnop|comm|comment|echo|einline|end[cmfpr]?|erem|even|fail|fpu|idnt|inline|jumpptr|list|llen|load|machine|mexit|mmu|nolist|nopage|nref|odd|offset|opword|org|output|page|plen|print[tv]|public|record|rem|rept|rorg|rsreset|rsset|set|setfo|setso|spc|text|ttl|weak|xdef|xref)\b
 
 - name: keyword.operator.assignment.m68k
   match: (?i)\b(equ(\.[sdxp])|set)\b

--- a/syntaxes/M68k-Assembly.tmLanguage.json
+++ b/syntaxes/M68k-Assembly.tmLanguage.json
@@ -176,7 +176,7 @@
     },
     {
       "name": "keyword.control.other.m68k",
-      "match": "(?i)\\b(align|cargs|clrfo|clrso|cnop|comm|comment|echo|einline|end[cmfpr]?|erem|even|fail|fpu|idnt|inline|jumpptr|list|llen|load|machine|mexit|mmu|nolist|nopage|nref|odd|offset|opword|org|output|page|plen|print[tv]|public|record|rem|rept|rorg|rsreset|rsset|set|setfo|setso|spc|text|ttl|weak|xdef|xref)\\b"
+      "match": "(?i)\\b(opt|align|cargs|clrfo|clrso|cnop|comm|comment|echo|einline|end[cmfpr]?|erem|even|fail|fpu|idnt|inline|jumpptr|list|llen|load|machine|mexit|mmu|nolist|nopage|nref|odd|offset|opword|org|output|page|plen|print[tv]|public|record|rem|rept|rorg|rsreset|rsset|set|setfo|setso|spc|text|ttl|weak|xdef|xref)\\b"
     },
     {
       "name": "keyword.operator.assignment.m68k",


### PR DESCRIPTION
Hello,

When reformatting following source, output is not correctly indented:

````
         OPT        O+,OW-,OW1+,OW6+,P=68000
init:
         move.w     d0,4(a0)
         move.w     d1,4(a1)
````
Is reformatted as:
````
         OPT        O+,OW-,OW1+,OW6+,P=68000
init:
                move.w     d0,4(a0)
                move.w     d1,4(a1)
````

This is because OPT is not recognized as an instruction and fall into the label category.
This PR aims at fixing it.

````
                OPT           O+,OW-,OW1+,OW6+,P=68000
init:
                move.w     d0,4(a0)
                move.w     d1,4(a1)
````


NOTE1: I've added support for OPT in the keyword.control.other.m68k because looking at other keywords,  I thought it was making sense. 

NOTE2: I've patched both json and yaml.. Just was too lazy to check if json is generated or not.
