### PR TITLE
macro should align as code

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -10,6 +10,7 @@ export class ASMLine {
     static m68kLang = new M68kLanguage();
     static commentLineRegExps = ASMLine.m68kLang.getAllRegExps(/.*comment\.line.*/g);
     static keywordsRegExps = ASMLine.m68kLang.getAllRegExps(/keyword.*/g);
+    static macrosRegExps = ASMLine.m68kLang.getAllRegExps(/macro.*/g);
     label: string = "";
     instruction: string = "";
     data: string = "";
@@ -82,6 +83,17 @@ export class ASMLine {
             }
             // find a keywork
             let keyword = this.search(ASMLine.keywordsRegExps, l);
+            if (!keyword) {
+                // no keyword
+                // Consider it is a label iif there are no leading spaces
+                if (leadingSpacesCount === 0) {
+                    this.label = l;
+                    this.labelRange = new Range(new Position(lineNumber, leadingSpacesCount), new Position(lineNumber, leadingSpacesCount + this.label.length));
+                }
+                else {
+                    keyword = this.search(ASMLine.macrosRegExps, l);
+                }
+            }
             if (keyword) {
                 // A keyword has been found
                 // set the keyword
@@ -113,11 +125,6 @@ export class ASMLine {
                 if (this.comment.length > 0) {
                     this.spacesDataToCommentRange = new Range(current, this.commentRange.start);
                 }
-            } else {
-                // no keyword
-                // Consider it is a label
-                this.label = l;
-                this.labelRange = new Range(new Position(lineNumber, leadingSpacesCount), new Position(lineNumber, leadingSpacesCount + this.label.length));
             }
         }
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -83,14 +83,10 @@ export class ASMLine {
             }
             // find a keywork
             let keyword = this.search(ASMLine.keywordsRegExps, l);
-            if (!keyword) {
-                // no keyword
+            if (!keyword && leadingSpacesCount !== 0) {
+                // it's not a keyword - this could be a macro iif there are leading spaces
                 // Consider it is a label iif there are no leading spaces
-                if (leadingSpacesCount === 0) {
-                    this.label = l;
-                    this.labelRange = new Range(new Position(lineNumber, leadingSpacesCount), new Position(lineNumber, leadingSpacesCount + this.label.length));
-                }
-                else {
+                if (leadingSpacesCount !== 0) {
                     keyword = this.search(ASMLine.macrosRegExps, l);
                 }
             }
@@ -125,6 +121,12 @@ export class ASMLine {
                 if (this.comment.length > 0) {
                     this.spacesDataToCommentRange = new Range(current, this.commentRange.start);
                 }
+            }
+            else {
+                // no keyword	
+                // Consider it is a label                
+                this.label = l;
+                this.labelRange = new Range(new Position(lineNumber, leadingSpacesCount), new Position(lineNumber, leadingSpacesCount + this.label.length));
             }
         }
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -121,10 +121,9 @@ export class ASMLine {
                 if (this.comment.length > 0) {
                     this.spacesDataToCommentRange = new Range(current, this.commentRange.start);
                 }
-            }
-            else {
-                // no keyword	
-                // Consider it is a label                
+            } else {
+                // no keyword
+                // Consider it is a label
                 this.label = l;
                 this.labelRange = new Range(new Position(lineNumber, leadingSpacesCount), new Position(lineNumber, leadingSpacesCount + this.label.length));
             }

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -165,6 +165,13 @@ describe("Parser Tests", function () {
             expect(asmLine.data).to.be.equal("#mempos,d1");
             expect(asmLine.comment).to.be.empty;
         });
+        it("Should parse macros as instruction", function () {
+            let asmLine = new ASMLine("\t\t    WAIT_BLITTER2 $FFF    ; mycomment");
+            expect(asmLine.label).to.be.empty;
+            expect(asmLine.instruction).to.be.equal("WAIT_BLITTER2");
+            expect(asmLine.data).to.be.equal("$FFF");
+            expect(asmLine.comment).to.be.equal("; mycomment");
+        });
     });
     context("Hover instruction file parsing", function () {
         it("Should read the file correctly", function () {

--- a/syntaxes/M68k-Assembly.YAML-tmLanguage
+++ b/syntaxes/M68k-Assembly.YAML-tmLanguage
@@ -142,3 +142,6 @@ patterns:
 
 - name: invalid.illegal.opcode.m68k
   match: (?i)\billegal\b
+
+- name: macro.m68k
+  match: "(?i)^([a-zA-Z0-9_][a-zA-Z0-9_\\.]*)"

--- a/syntaxes/M68k-Assembly.tmLanguage.json
+++ b/syntaxes/M68k-Assembly.tmLanguage.json
@@ -201,6 +201,10 @@
     {
       "name": "invalid.illegal.opcode.m68k",
       "match": "(?i)\\billegal\\b"
+    },
+    {
+      "name": "macro.m68k",
+      "match": "(?i)^([a-zA-Z0-9_][a-zA-Z0-9_\\.]*)"
     }
   ]
 }


### PR DESCRIPTION
Hello,

When reformatting following source, output is not correctly indented:

````
flip_screens
    movem.l work_coplist-_Base(a5),a0-a3
    exg a0,a1  ; swap coplist
    exg a2,a3  ; swap bitplans
    movem.l a0-a3,work_coplist-_Base(a5)
    WAIT_BLITTER2 $FFF
    move.l a1,cop1lc(a6)
    stop #$2200         ; wait for next vbl to happen
    rts   
````
Is reformatted as:
````
flip_screens
        movem.l work_coplist-_Base(a5),a0-a3
        exg a0,a1  ; swap coplist
        exg a2,a3  ; swap bitplans
        movem.l a0-a3,work_coplist-_Base(a5)
    WAIT_BLITTER2 $FFF
        move.l a1,cop1lc(a6)
        stop #$2200                                                  ; wait for next vbl to happen
        rts   
````

This is because what is not matched as an instruction falls into the label category.
Another fix so as it's really easier to read macro aligned with code.

Now the output is:
````
flip_screens
        movem.l work_coplist-_Base(a5),a0-a3
        exg a0,a1  ; swap coplist
        exg a2,a3  ; swap bitplans
        movem.l a0-a3,work_coplist-_Base(a5)
        WAIT_BLITTER2 $FFF
        move.l a1,cop1lc(a6)
        stop #$2200                                                  ; wait for next vbl to happen
        rts   
````

NOTE1: I've added a new category in the syntax file (macros.m68k) because I could not find a suitable category.

NOTE2: Same as other PR, I'm still too lazy to check if syntax json is generated or not. Guidance welcome anyway to learn where to look at !