### PR TITLE
Entrypoint option for the linker

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,6 +241,10 @@
                             "type": "string",
                             "description": "GlobPattern to select the source files to exclude from the link"
                         },
+                        "entrypoint": {
+                            "type": "string",
+                            "description": "Name of the object file containing the entrypoint"
+                        },
                         "exefilename": {
                             "type": "string",
                             "description": "Name of the executable file"

--- a/src/vasm.ts
+++ b/src/vasm.ts
@@ -105,7 +105,8 @@ export class VASMCompiler {
                     let includes = confVLINK.includes;
                     let excludes = confVLINK.excludes;
                     let exefilename = confVLINK.exefilename;
-                    await this.buildWorkspaceInner(includes, excludes, exefilename).then(() => {
+                    let entrypoint = confVLINK.entrypoint;
+                    await this.buildWorkspaceInner(includes, excludes, exefilename, entrypoint).then(() => {
                         resolve();
                     }).catch(err => {
                         reject(err);
@@ -153,7 +154,7 @@ export class VASMCompiler {
         });
     }
 
-    private buildWorkspaceInner(includes: string, excludes: string, exefilename: string): Promise<void> {
+    private buildWorkspaceInner(includes: string, excludes: string, exefilename: string, entrypoint: string|undefined): Promise<void> {
         return new Promise(async (resolve, reject) => {
             const workspaceRootDir = this.getWorkspaceRootDir();
             const buildDir = this.getBuildDir();
@@ -177,7 +178,7 @@ export class VASMCompiler {
                         }
                         // Call the linker
                         if (this.linker.mayLink(confVLINK)) {
-                            await this.linker.linkFiles(filesURI, exefilename, workspaceRootDir, buildDir).then(errors => {
+                            await this.linker.linkFiles(filesURI, exefilename, entrypoint, workspaceRootDir, buildDir).then(errors => {
                                 if (errors && errors.length > 0) {
                                     reject(new Error(`Linker error: ${errors[0].msg}`));
                                 } else {


### PR DESCRIPTION
Adds an option to the vlink tool in order to allow reordering objects, and thus, defining the entrypoint of the executable.