### PR TITLE
Fix color picker float <-> hex calculations

### DIFF
--- a/src/color.ts
+++ b/src/color.ts
@@ -51,9 +51,9 @@ export class M86kColorProvider implements DocumentColorProvider {
             if (value.length > 3) {
                 pos = 1;
             }
-            let r = parseInt(value[pos++], 16) / 32;
-            let g = parseInt(value[pos++], 16) / 32;
-            let b = parseInt(value[pos], 16) / 32;
+            let r = parseInt(value[pos++], 16) / 15;
+            let g = parseInt(value[pos++], 16) / 15;
+            let b = parseInt(value[pos], 16) / 15;
 
             let color: Color = new Color(r, g, b, 1);
             colors.push(new ColorInformation(range, color));
@@ -73,9 +73,9 @@ export class M86kColorProvider implements DocumentColorProvider {
             prefix += documentText[1];
         }
         return prefix +
-            this.formatColorComponent(color.red * 32) +
-            this.formatColorComponent(color.green * 32) +
-            this.formatColorComponent(color.blue * 32);
+            this.formatColorComponent(color.red * 15) +
+            this.formatColorComponent(color.green * 15) +
+            this.formatColorComponent(color.blue * 15);
     }
 
     /**


### PR DESCRIPTION
The previous code would convert a color float (0.0-1.0) to a range of 0-32 and vice versa, but Amiga colors are range 0-15 ($0 to $f). This would cause the color preview icons and the output value from the color picker to be inaccurate.

Before fix:
![2021-11-17_01-01-53](https://user-images.githubusercontent.com/7810794/142159646-13bdf42e-418e-4971-8b33-46fd1f093b96.png)

After fix:
![2021-11-17_01-02-20](https://user-images.githubusercontent.com/7810794/142159693-3a41df97-52fc-4416-bf3c-684aeed65eb4.png)
