### PR TITLE
Data Generator minor fixes

### DIFF
--- a/src/expressionDataGenerator.ts
+++ b/src/expressionDataGenerator.ts
@@ -58,8 +58,8 @@ export class ExpressionDataGenerator {
         let posLine = 0;
         let value = "";
         let type = 'b';
-        let max = Number.MIN_VALUE;
-        let min = Number.MAX_VALUE;
+        let max = 0;
+        let min = 0;
         let signed = false;
         if (this.outputDataType === OutputDataType.WORD) {
             type = 'w';
@@ -77,11 +77,11 @@ export class ExpressionDataGenerator {
                 signed = (v < 0);
             }
             // check validity
-            if ((this.outputDataType === OutputDataType.BYTE) && (v > 255)) {
+            if ((this.outputDataType === OutputDataType.BYTE) && (v > 0xff)) {
                 throw new Error(`Value ${v} does not fit in a byte register`);
-            } else if ((this.outputDataType === OutputDataType.WORD) && (v > 0x8000)) {
+            } else if ((this.outputDataType === OutputDataType.WORD) && (v > 0xffff)) {
                 throw new Error(`Value ${v} does not fit in a word (16bits) register`);
-            } else if ((this.outputDataType === OutputDataType.LONG) && (v > 0x80000000)) {
+            } else if ((this.outputDataType === OutputDataType.LONG) && (v > 0xffffffff)) {
                 throw new Error(`Value ${v} does not fit in a long (32bits) register`);
             }
             if ((this.valuesPerLine > 0) && (posLine >= this.valuesPerLine)) {
@@ -104,11 +104,11 @@ export class ExpressionDataGenerator {
         }
         // check boundaries
         if (signed) {
-            if ((this.outputDataType === OutputDataType.BYTE) && ((max > 0x7f) || (min < -0x7f))) {
+            if ((this.outputDataType === OutputDataType.BYTE) && ((max > 0x7f) || (min < -0x80))) {
                 throw new Error(`The data boundaries ${min} - ${max} does not fit in a signed byte register`);
-            } else if ((this.outputDataType === OutputDataType.WORD) && ((max > 0x7fff) || (min < -0x7fff))) {
+            } else if ((this.outputDataType === OutputDataType.WORD) && ((max > 0x7fff) || (min < -0x8000))) {
                 throw new Error(`The data boundaries ${min} - ${max} does not fit in a signed word (16bits) register`);
-            } else if ((this.outputDataType === OutputDataType.LONG) && ((max > 0x7fffffff) || (min < -0x7fffffff))) {
+            } else if ((this.outputDataType === OutputDataType.LONG) && ((max > 0x7fffffff) || (min < -0x80000000))) {
                 throw new Error(`The data boundaries ${min} - ${max} does not fit in a signed long (32bits) register`);
             }
             value = ExpressionDataGenerator.SIGNED_VALUES_COMMENT + value;
@@ -119,17 +119,17 @@ export class ExpressionDataGenerator {
         let padSize = 0;
         if (n < 0) {
             if (this.outputDataType === OutputDataType.BYTE) {
-                if (n < -0x7f) {
+                if (n < -0x80) {
                     throw (new Error(`Invalid negative number for a byte: ${n}`));
                 }
                 n = (n >>> 0) & 0xff;
             } else if (this.outputDataType === OutputDataType.WORD) {
-                if (n < -0x7fff) {
+                if (n < -0x8000) {
                     throw (new Error(`Invalid negative number for a byte: ${n}`));
                 }
                 n = (n >>> 0) & 0xffff;
             } else {
-                if (n < -0x7fffffff) {
+                if (n < -0x80000000) {
                     throw (new Error(`Invalid negative number for a byte: ${n}`));
                 }
                 n = (n >>> 0);

--- a/src/expressionDataGenerator.ts
+++ b/src/expressionDataGenerator.ts
@@ -308,11 +308,13 @@ export class DataGeneratorCodeLensProvider implements vscode.CodeLensProvider {
         const text = document.getText();
         let linePos = 0;
         let startPos: vscode.Position | null = null;
-        for (const line of text.split('\n')) {
+        let lines = text.split('\n');
+        for (const line of lines) {
             if (line.includes(ExpressionDataGeneratorSerializer.START_KEYWORD)) {
                 startPos = new vscode.Position(linePos, 0);
             } else if (line.includes(ExpressionDataGeneratorSerializer.END_KEYWORD) && startPos) {
-                const range = new vscode.Range(startPos, new vscode.Position(linePos, line.length));
+                let newline = lines[linePos + 1] == '' ? 1 : 0;
+                const range = new vscode.Range(startPos, new vscode.Position(linePos + newline, line.length));
                 rangesArray.push(range);
             }
             linePos++;


### PR DESCRIPTION
This contains a couple minor bugfixes for the Data Generator.

- Unsigned words and longs now correctly max out at 0xffff(ffff) instead of 0x8000(0000).
- Signed values can be range 127 to -128, but the minimum signed values were incorrectly -0x7f (-127) instead of -0x80 (-128). The boundaries are now corrected to be minimum -0x80. This applies to bytes, words, and longs (although I used bytes in this example).
- There was a bug where repeatedly clicking "Generate data" would continually add new lines to the bottom of the generation. This fix checks if a newline is already present below the data generator, and overwrites it if so.