### PR TITLE
Require whitespace before opcodes/control words

### DIFF
--- a/src/test/formatter.test.ts
+++ b/src/test/formatter.test.ts
@@ -335,6 +335,15 @@ describe("Formatter Tests", function () {
         expect(edits[i++]).to.be.eql(TextEdit.replace(new Range(new Position(4, 18), new Position(4, 22)), " ".repeat(4)));
         expect(edits[i]).to.be.eql(TextEdit.replace(new Range(new Position(4, 0), new Position(4, 8)), " ".repeat(2)));
     });
-
+    it("Should allow opcode names in labels", function () {
+        const f = new M68kFormatter();
+        const document = new DummyTextDocument();
+        document.addLine(".end:");
+        const asmDocument = new ASMDocument();
+        const conf = new DocumentFormatterConfiguration(2, 4, 4, 1, 1, 0, 0, false, 4);
+        asmDocument.parse(document, conf);
+        let edits = f.computeEditsForLine(asmDocument, asmDocument.asmLinesArray[0], conf);
+        expect(edits.length).to.be.equal(0);
+    });
 });
 

--- a/src/test/language.test.ts
+++ b/src/test/language.test.ts
@@ -30,9 +30,9 @@ describe("Language Tests", function () {
         it("Should get a correct regex from it's name", function () {
             const r: RegExp | null = l.getRegExp("keyword.other.opcode.cpu.bwl.m68k");
             if (r !== null) {
-                expect(r.test("move")).to.be.true;
+                expect(r.test(" move")).to.be.true;
                 // must ignore the case for this keyword
-                expect(r.test("MOVE")).to.be.true;
+                expect(r.test(" MOVE")).to.be.true;
             } else {
                 fail("Regexp not found");
             }
@@ -45,7 +45,7 @@ describe("Language Tests", function () {
         it("Should get a correct list of regex from a regex on it's name", function () {
             const list: Array<RegExp> = l.getAllRegExps(/.*opcode.cpu.*/);
             expect(list.length).to.be.equal(13);
-            expect(list[0].test("bchg.l")).to.be.true;
+            expect(list[0].test(" bchg.l")).to.be.true;
         });
         it("Should get the list of possible extensions for an instruction", function () {
             expect(l.getExtensions('move')).to.be.eql(['b', 'w', 'l']);

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -357,6 +357,14 @@ describe("Parser Tests", function () {
             pos += 5 + 2;
             expect(numbers[4]).to.be.eql(['@-12', new Range(new Position(0, pos), new Position(0, pos + 4))]);
         });
+        it("Should allow opcode names in labels", function () {
+            let asmLine = new ASMLine("end");
+            expect(asmLine.label).to.be.equal('end');
+            expect(asmLine.instruction).to.be.empty
+            asmLine = new ASMLine(".end");
+            expect(asmLine.label).to.be.equal('.end');
+            expect(asmLine.instruction).to.be.empty
+        });
     });
     context("Number parsing", function () {
         it("Should parse a number", function () {

--- a/syntaxes/Dbg-Assembly.YAML-tmLanguage
+++ b/syntaxes/Dbg-Assembly.YAML-tmLanguage
@@ -42,52 +42,52 @@ patterns:
   match: (?i)\b([ad][0-7]|SP|PC|vbr|fp[0-7])\b
 
 - name: keyword.other.opcode.cpu.bl.m68k
-  match: (?i)\b(bchg|bclr|bset|btst)(\.[bl])?\b
+  match: (?i)(?<=\s)(bchg|bclr|bset|btst)(\.[bl])?\b
 
 - name: keyword.other.opcode.cpu.bwl.m68k
-  match: (?i)\b(lsr|move|tst|moves|wddata|neg|negx|not|or|ori|addq|addi|addx|and|andi|asl|asr|cas|chk2|clr|cmp|cmpi|cmpm|cmp2|eor|eori|rol|ror|roxl|roxr|sub|subi|subq|subx|tbls|tblsn|tblu|tblun|add|lsl)(\.[bwl])?\b
+  match: (?i)(?<=\s)(lsr|move|tst|moves|wddata|neg|negx|not|or|ori|addq|addi|addx|and|andi|asl|asr|cas|chk2|clr|cmp|cmpi|cmpm|cmp2|eor|eori|rol|ror|roxl|roxr|sub|subi|subq|subx|tbls|tblsn|tblu|tblun|add|lsl)(\.[bwl])?\b
 
 - name: keyword.other.opcode.cpu.bwlsdxp.m68k
-  match: (?i)\b(fsincos|ftst)(\.[bwlsdxp])?\b
+  match: (?i)(?<=\s)(fsincos|ftst)(\.[bwlsdxp])?\b
 
 - name: keyword.other.opcode.cpu.wl.m68k
-  match: (?i)\b(maaac|mac|traplo|masac|trapne|trapeq|movea|movem|traple|movep|movm|msaac|msac|mssac|muls|mulu|pbbs|pbbc|adda|pblc|pbss|pbls|pbsc|pbas|pbac|pbws|pbwc|pbis|pbic|pbgs|pbgc|pbcs|pbcc|cas2|chk|cmpa|ptrapbs|ptrapbc|ptrapls|ptraplc|ptrapss|ptrapsc|ptrapas|ptrapac|ptrapws|ptrapwc|ptrapis|divs|ptrapic|ptrapgs|divu|ptrapgc|ptrapcs|ptrapcc|ext|fbf|fbeq|fbogt|fboge|fbolt|fbole|fbogl|fbor|fbun|fbueq|fbugt|fbuge|fbult|fbule|fbne|fbt|fbsf|fbseq|fbgt|fbge|fblt|fble|fbgl|fbgle|suba|fbngle|fbngl|fbnle|fbnlt|fbnge|fbngt|fbsne|fbst|tpf|trapt|trapf|traphi|trapls|trapcc|traphs|trapcs|trapge|trapmi|trappl|trapvs|trapvc|traplt|link|trapgt|ftrapf|ftrapeq|ftrapogt|ftrapoge|ftrapolt|ftrapole|ftrapogl|ftrapor|ftrapun|ftrapueq|ftrapugt|ftrapuge|ftrapult|ftrapule|ftrapne|ftrapt|ftrapsf|ftrapseq|ftrapgt|ftrapge|ftraplt|ftraple|ftrapgl|ftrapgle|ftrapngle|ftrapngl|ftrapnle|ftrapnlt|ftrapnge|ftrapngt|ftrapsne|ftrapst)(\.[wl])?\b
+  match: (?i)(?<=\s)(maaac|mac|traplo|masac|trapne|trapeq|movea|movem|traple|movep|movm|msaac|msac|mssac|muls|mulu|pbbs|pbbc|adda|pblc|pbss|pbls|pbsc|pbas|pbac|pbws|pbwc|pbis|pbic|pbgs|pbgc|pbcs|pbcc|cas2|chk|cmpa|ptrapbs|ptrapbc|ptrapls|ptraplc|ptrapss|ptrapsc|ptrapas|ptrapac|ptrapws|ptrapwc|ptrapis|divs|ptrapic|ptrapgs|divu|ptrapgc|ptrapcs|ptrapcc|ext|fbf|fbeq|fbogt|fboge|fbolt|fbole|fbogl|fbor|fbun|fbueq|fbugt|fbuge|fbult|fbule|fbne|fbt|fbsf|fbseq|fbgt|fbge|fblt|fble|fbgl|fbgle|suba|fbngle|fbngl|fbnle|fbnlt|fbnge|fbngt|fbsne|fbst|tpf|trapt|trapf|traphi|trapls|trapcc|traphs|trapcs|trapge|trapmi|trappl|trapvs|trapvc|traplt|link|trapgt|ftrapf|ftrapeq|ftrapogt|ftrapoge|ftrapolt|ftrapole|ftrapogl|ftrapor|ftrapun|ftrapueq|ftrapugt|ftrapuge|ftrapult|ftrapule|ftrapne|ftrapt|ftrapsf|ftrapseq|ftrapgt|ftrapge|ftraplt|ftraple|ftrapgl|ftrapgle|ftrapngle|ftrapngl|ftrapnle|ftrapnlt|ftrapnge|ftrapngt|ftrapsne|ftrapst)(\.[wl])?\b
 
 - name: keyword.other.opcode.cpu.m68k
-  match: (?i)\b(move16|unlk|unpk|nop|reset|pack|stop|bfchg|pflush|bfclr|pflusha|bfexts|pflushan|bfextu|pflushn|bfffo|pflushr|bfins|pflushs|bfset|ploadr|bftst|ploadw|bgnd|plpar|plpaw|bkpt|callm|prestore|psave|cinvl|cinvp|cinva|cpushl|cpushp|cpusha|ptestr|ptestw|pulse|rtd|rte|rtm|rtr|rts|trap|trapv|fnop|frestore|fsave|halt|illegal|intouch|jmp|jsr|linea|line_a|linef|line_f)\b
+  match: (?i)(?<=\s)(move16|unlk|unpk|nop|reset|pack|stop|bfchg|pflush|bfclr|pflusha|bfexts|pflushan|bfextu|pflushn|bfffo|pflushr|bfins|pflushs|bfset|ploadr|bftst|ploadw|bgnd|plpar|plpaw|bkpt|callm|prestore|psave|cinvl|cinvp|cinva|cpushl|cpushp|cpusha|ptestr|ptestw|pulse|rtd|rte|rtm|rtr|rts|trap|trapv|fnop|frestore|fsave|halt|illegal|intouch|jmp|jsr|linea|line_a|linef|line_f)\b
 
 - name: keyword.other.opcode.cpu.bwls.m68k
-  match: (?i)\b(bhs|blo|bhi|bls|bcc|bcs|bne|beq|bvc|bvs|bpl|bmi|bge|blt|bgt|ble|bra|bsr|jbhs|jblo|jbhi|jbls|jbcc|jbcs|jbne|jbeq|jbvc|jbvs|jbpl|jbmi|jbge|jblt|jbgt|jble|jbra|jbsr)(\.[bwls])?\b
+  match: (?i)(?<=\s)(bhs|blo|bhi|bls|bcc|bcs|bne|beq|bvc|bvs|bpl|bmi|bge|blt|bgt|ble|bra|bsr|jbhs|jblo|jbhi|jbls|jbcc|jbcs|jbne|jbeq|jbvc|jbvs|jbpl|jbmi|jbge|jblt|jbgt|jble|jbra|jbsr)(\.[bwls])?\b
 
 - name: keyword.other.opcode.cpu.ld.m68k
-  match: (?i)\b(pmovefd)(\.[ld])?\b
+  match: (?i)(?<=\s)(pmovefd)(\.[ld])?\b
 
 - name: keyword.other.opcode.cpu.l.m68k
-  match: (?i)\b(mov3q|movclr|movec|moveq|wdebug|pea|bitrev|byterev|divsl|divul|exg|pvalid|rems|extb|remu|sats|ff1|lea)(\.[l])?\b
+  match: (?i)(?<=\s)(mov3q|movclr|movec|moveq|wdebug|pea|bitrev|byterev|divsl|divul|exg|pvalid|rems|extb|remu|sats|ff1|lea)(\.[l])?\b
 
 - name: keyword.other.opcode.cpu.w.m68k
-  match: (?i)\b(lpstop|pdbbs|pdbbc|pdbls|pdblc|pdbss|pdbsc|pdbas|pdbac|pdbws|pdbwc|pdbis|pdbic|pdbgs|pdbgc|pdbcs|pdbcc|dbt|dbf|dbra|dbhi|dbls|dbcc|dbhs|dbcs|dblo|dbne|dbvs|dbeq|dbpl|dbvc|dbmi|dbge|dblt|dbgt|dble|strldsr|swap|fdbf|fdbeq|fdbogt|fdboge|fdbolt|fdbole|fdbogl|fdbor|fdbun|fdbueq|fdbugt|fdbuge|fdbult|fdbule|fdbne|fdbt|fdbsf|fdbseq|fdbgt|fdbge|fdblt|fdble|fdbgl|fdbgle|fdbngle|fdbngl|fdbnle|fdbnlt|fdbnge|fdbngt|fdbsne|fdbst)(\.[w])?\b
+  match: (?i)(?<=\s)(lpstop|pdbbs|pdbbc|pdbls|pdblc|pdbss|pdbsc|pdbas|pdbac|pdbws|pdbwc|pdbis|pdbic|pdbgs|pdbgc|pdbcs|pdbcc|dbt|dbf|dbra|dbhi|dbls|dbcc|dbhs|dbcs|dblo|dbne|dbvs|dbeq|dbpl|dbvc|dbmi|dbge|dblt|dbgt|dble|strldsr|swap|fdbf|fdbeq|fdbogt|fdboge|fdbolt|fdbole|fdbogl|fdbor|fdbun|fdbueq|fdbugt|fdbuge|fdbult|fdbule|fdbne|fdbt|fdbsf|fdbseq|fdbgt|fdbge|fdblt|fdble|fdbgl|fdbgle|fdbngle|fdbngl|fdbnle|fdbnlt|fdbnge|fdbngt|fdbsne|fdbst)(\.[w])?\b
 
 - name: keyword.other.opcode.cpu.b.m68k
-  match: (?i)\b(nbcd|abcd|psbs|psbc|psls|pslc|psss|pssc|psas|psac|psws|pswc|psis|psic|psgs|psgc|pscs|pscc|sbcd|st|sf|shi|sls|scc|shs|scs|slo|sne|seq|svc|svs|spl|smi|sge|slt|sgt|sle|tas|fsf|fseq|fsogt|fsoge|fsolt|fsole|fsogl|fsor|fsun|fsueq|fsugt|fsuge|fsult|fsule|fsne|fst|fssf|fsseq|fsgt|fsge|fslt|fsle|fsgl|fsgle|fsngle|fsngl|fsnle|fsnlt|fsnge|fsngt|fssne|fsst)(\.[b])?\b
+  match: (?i)(?<=\s)(nbcd|abcd|psbs|psbc|psls|pslc|psss|pssc|psas|psac|psws|pswc|psis|psic|psgs|psgc|pscs|pscc|sbcd|st|sf|shi|sls|scc|shs|scs|slo|sne|seq|svc|svs|spl|smi|sge|slt|sgt|sle|tas|fsf|fseq|fsogt|fsoge|fsolt|fsole|fsogl|fsor|fsun|fsueq|fsugt|fsuge|fsult|fsule|fsne|fst|fssf|fsseq|fsgt|fsge|fslt|fsle|fsgl|fsgle|fsngle|fsngl|fsnle|fsnlt|fsnge|fsngt|fssne|fsst)(\.[b])?\b
 
 - name: keyword.other.opcode.cpu.bw.m68k
-  match: (?i)\b(mvs|mvz)(\.[bw])?\b
+  match: (?i)(?<=\s)(mvs|mvz)(\.[bw])?\b
 
 - name: keyword.other.opcode.cpu.bwld.m68k
-  match: (?i)\b(pmove)(\.[bwld])?\b
+  match: (?i)(?<=\s)(pmove)(\.[bwld])?\b
 
 - name: keyword.other.opcode.cpu.ldx.m68k
-  match: (?i)\b(fmovem)(\.[ldx])?\b
+  match: (?i)(?<=\s)(fmovem)(\.[ldx])?\b
 
 - name: keyword.other.opcode.fpu.x.m68k
-  match: (?i)\b(fmovecr)(\.[x])?\b
+  match: (?i)(?<=\s)(fmovecr)(\.[x])?\b
 
 - name: keyword.other.opcode.fpu.bwlsdxp.m68k
-  match: (?i)\b(fabs|fsabs|fdabs|facos|fadd|fsadd|fdadd|fasin|fatan|fatanh|fcmp|fcos|fcosh|fdiv|fsdiv|fddiv|fetox|fetoxm1|fgetexp|fgetman|fint|fintrz|flog10|flog2|flogn|flognp1|fmod|fmove|fsmove|fdmove|fmul|fsmul|fdmul|fneg|fsneg|fdneg|frem|fscale|fsgldiv|fsglmul|fsin|fsinh|fsqrt|fssqrt|fdsqrt|fsub|fssub|fdsub|ftan|ftanh|ftentox|ftwotox)(\.[bwlsdxp])?\b
+  match: (?i)(?<=\s)(fabs|fsabs|fdabs|facos|fadd|fsadd|fdadd|fasin|fatan|fatanh|fcmp|fcos|fcosh|fdiv|fsdiv|fddiv|fetox|fetoxm1|fgetexp|fgetman|fint|fintrz|flog10|flog2|flogn|flognp1|fmod|fmove|fsmove|fdmove|fmul|fsmul|fdmul|fneg|fsneg|fdneg|frem|fscale|fsgldiv|fsglmul|fsin|fsinh|fsqrt|fssqrt|fdsqrt|fsub|fssub|fdsub|ftan|ftanh|ftentox|ftwotox)(\.[bwlsdxp])?\b
 
 - name: keyword.other.opcode.mem.m68k
-  match: (?i)\b(blk|dc|dcb|ds)(\.[bdlqswx])?\b
+  match: (?i)(?<=\s)(blk|dc|dcb|ds)(\.[bdlqswx])?\b
 
 - name: keyword.other.opcode.pc.m68k
-  match: (?i)\b(dr)(\.[bwl])?\b
+  match: (?i)(?<=\s)(dr)(\.[bwl])?\b

--- a/syntaxes/Dbg-Assembly.tmLanguage.json
+++ b/syntaxes/Dbg-Assembly.tmLanguage.json
@@ -56,71 +56,71 @@
     },
     {
       "name": "keyword.other.opcode.cpu.bl.m68k",
-      "match": "(?i)\\b(bchg|bclr|bset|btst)(\\.[bl])?\\b"
+      "match": "(?i)(?<=\\s)(bchg|bclr|bset|btst)(\\.[bl])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.bwl.m68k",
-      "match": "(?i)\\b(lsr|move|tst|moves|wddata|neg|negx|not|or|ori|addq|addi|addx|and|andi|asl|asr|cas|chk2|clr|cmp|cmpi|cmpm|cmp2|eor|eori|rol|ror|roxl|roxr|sub|subi|subq|subx|tbls|tblsn|tblu|tblun|add|lsl)(\\.[bwl])?\\b"
+      "match": "(?i)(?<=\\s)(lsr|move|tst|moves|wddata|neg|negx|not|or|ori|addq|addi|addx|and|andi|asl|asr|cas|chk2|clr|cmp|cmpi|cmpm|cmp2|eor|eori|rol|ror|roxl|roxr|sub|subi|subq|subx|tbls|tblsn|tblu|tblun|add|lsl)(\\.[bwl])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.bwlsdxp.m68k",
-      "match": "(?i)\\b(fsincos|ftst)(\\.[bwlsdxp])?\\b"
+      "match": "(?i)(?<=\\s)(fsincos|ftst)(\\.[bwlsdxp])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.wl.m68k",
-      "match": "(?i)\\b(maaac|mac|traplo|masac|trapne|trapeq|movea|movem|traple|movep|movm|msaac|msac|mssac|muls|mulu|pbbs|pbbc|adda|pblc|pbss|pbls|pbsc|pbas|pbac|pbws|pbwc|pbis|pbic|pbgs|pbgc|pbcs|pbcc|cas2|chk|cmpa|ptrapbs|ptrapbc|ptrapls|ptraplc|ptrapss|ptrapsc|ptrapas|ptrapac|ptrapws|ptrapwc|ptrapis|divs|ptrapic|ptrapgs|divu|ptrapgc|ptrapcs|ptrapcc|ext|fbf|fbeq|fbogt|fboge|fbolt|fbole|fbogl|fbor|fbun|fbueq|fbugt|fbuge|fbult|fbule|fbne|fbt|fbsf|fbseq|fbgt|fbge|fblt|fble|fbgl|fbgle|suba|fbngle|fbngl|fbnle|fbnlt|fbnge|fbngt|fbsne|fbst|tpf|trapt|trapf|traphi|trapls|trapcc|traphs|trapcs|trapge|trapmi|trappl|trapvs|trapvc|traplt|link|trapgt|ftrapf|ftrapeq|ftrapogt|ftrapoge|ftrapolt|ftrapole|ftrapogl|ftrapor|ftrapun|ftrapueq|ftrapugt|ftrapuge|ftrapult|ftrapule|ftrapne|ftrapt|ftrapsf|ftrapseq|ftrapgt|ftrapge|ftraplt|ftraple|ftrapgl|ftrapgle|ftrapngle|ftrapngl|ftrapnle|ftrapnlt|ftrapnge|ftrapngt|ftrapsne|ftrapst)(\\.[wl])?\\b"
+      "match": "(?i)(?<=\\s)(maaac|mac|traplo|masac|trapne|trapeq|movea|movem|traple|movep|movm|msaac|msac|mssac|muls|mulu|pbbs|pbbc|adda|pblc|pbss|pbls|pbsc|pbas|pbac|pbws|pbwc|pbis|pbic|pbgs|pbgc|pbcs|pbcc|cas2|chk|cmpa|ptrapbs|ptrapbc|ptrapls|ptraplc|ptrapss|ptrapsc|ptrapas|ptrapac|ptrapws|ptrapwc|ptrapis|divs|ptrapic|ptrapgs|divu|ptrapgc|ptrapcs|ptrapcc|ext|fbf|fbeq|fbogt|fboge|fbolt|fbole|fbogl|fbor|fbun|fbueq|fbugt|fbuge|fbult|fbule|fbne|fbt|fbsf|fbseq|fbgt|fbge|fblt|fble|fbgl|fbgle|suba|fbngle|fbngl|fbnle|fbnlt|fbnge|fbngt|fbsne|fbst|tpf|trapt|trapf|traphi|trapls|trapcc|traphs|trapcs|trapge|trapmi|trappl|trapvs|trapvc|traplt|link|trapgt|ftrapf|ftrapeq|ftrapogt|ftrapoge|ftrapolt|ftrapole|ftrapogl|ftrapor|ftrapun|ftrapueq|ftrapugt|ftrapuge|ftrapult|ftrapule|ftrapne|ftrapt|ftrapsf|ftrapseq|ftrapgt|ftrapge|ftraplt|ftraple|ftrapgl|ftrapgle|ftrapngle|ftrapngl|ftrapnle|ftrapnlt|ftrapnge|ftrapngt|ftrapsne|ftrapst)(\\.[wl])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.m68k",
-      "match": "(?i)\\b(move16|unlk|unpk|nop|reset|pack|stop|bfchg|pflush|bfclr|pflusha|bfexts|pflushan|bfextu|pflushn|bfffo|pflushr|bfins|pflushs|bfset|ploadr|bftst|ploadw|bgnd|plpar|plpaw|bkpt|callm|prestore|psave|cinvl|cinvp|cinva|cpushl|cpushp|cpusha|ptestr|ptestw|pulse|rtd|rte|rtm|rtr|rts|trap|trapv|fnop|frestore|fsave|halt|illegal|intouch|jmp|jsr|linea|line_a|linef|line_f)\\b"
+      "match": "(?i)(?<=\\s)(move16|unlk|unpk|nop|reset|pack|stop|bfchg|pflush|bfclr|pflusha|bfexts|pflushan|bfextu|pflushn|bfffo|pflushr|bfins|pflushs|bfset|ploadr|bftst|ploadw|bgnd|plpar|plpaw|bkpt|callm|prestore|psave|cinvl|cinvp|cinva|cpushl|cpushp|cpusha|ptestr|ptestw|pulse|rtd|rte|rtm|rtr|rts|trap|trapv|fnop|frestore|fsave|halt|illegal|intouch|jmp|jsr|linea|line_a|linef|line_f)\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.bwls.m68k",
-      "match": "(?i)\\b(bhs|blo|bhi|bls|bcc|bcs|bne|beq|bvc|bvs|bpl|bmi|bge|blt|bgt|ble|bra|bsr|jbhs|jblo|jbhi|jbls|jbcc|jbcs|jbne|jbeq|jbvc|jbvs|jbpl|jbmi|jbge|jblt|jbgt|jble|jbra|jbsr)(\\.[bwls])?\\b"
+      "match": "(?i)(?<=\\s)(bhs|blo|bhi|bls|bcc|bcs|bne|beq|bvc|bvs|bpl|bmi|bge|blt|bgt|ble|bra|bsr|jbhs|jblo|jbhi|jbls|jbcc|jbcs|jbne|jbeq|jbvc|jbvs|jbpl|jbmi|jbge|jblt|jbgt|jble|jbra|jbsr)(\\.[bwls])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.ld.m68k",
-      "match": "(?i)\\b(pmovefd)(\\.[ld])?\\b"
+      "match": "(?i)(?<=\\s)(pmovefd)(\\.[ld])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.l.m68k",
-      "match": "(?i)\\b(mov3q|movclr|movec|moveq|wdebug|pea|bitrev|byterev|divsl|divul|exg|pvalid|rems|extb|remu|sats|ff1|lea)(\\.[l])?\\b"
+      "match": "(?i)(?<=\\s)(mov3q|movclr|movec|moveq|wdebug|pea|bitrev|byterev|divsl|divul|exg|pvalid|rems|extb|remu|sats|ff1|lea)(\\.[l])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.w.m68k",
-      "match": "(?i)\\b(lpstop|pdbbs|pdbbc|pdbls|pdblc|pdbss|pdbsc|pdbas|pdbac|pdbws|pdbwc|pdbis|pdbic|pdbgs|pdbgc|pdbcs|pdbcc|dbt|dbf|dbra|dbhi|dbls|dbcc|dbhs|dbcs|dblo|dbne|dbvs|dbeq|dbpl|dbvc|dbmi|dbge|dblt|dbgt|dble|strldsr|swap|fdbf|fdbeq|fdbogt|fdboge|fdbolt|fdbole|fdbogl|fdbor|fdbun|fdbueq|fdbugt|fdbuge|fdbult|fdbule|fdbne|fdbt|fdbsf|fdbseq|fdbgt|fdbge|fdblt|fdble|fdbgl|fdbgle|fdbngle|fdbngl|fdbnle|fdbnlt|fdbnge|fdbngt|fdbsne|fdbst)(\\.[w])?\\b"
+      "match": "(?i)(?<=\\s)(lpstop|pdbbs|pdbbc|pdbls|pdblc|pdbss|pdbsc|pdbas|pdbac|pdbws|pdbwc|pdbis|pdbic|pdbgs|pdbgc|pdbcs|pdbcc|dbt|dbf|dbra|dbhi|dbls|dbcc|dbhs|dbcs|dblo|dbne|dbvs|dbeq|dbpl|dbvc|dbmi|dbge|dblt|dbgt|dble|strldsr|swap|fdbf|fdbeq|fdbogt|fdboge|fdbolt|fdbole|fdbogl|fdbor|fdbun|fdbueq|fdbugt|fdbuge|fdbult|fdbule|fdbne|fdbt|fdbsf|fdbseq|fdbgt|fdbge|fdblt|fdble|fdbgl|fdbgle|fdbngle|fdbngl|fdbnle|fdbnlt|fdbnge|fdbngt|fdbsne|fdbst)(\\.[w])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.b.m68k",
-      "match": "(?i)\\b(nbcd|abcd|psbs|psbc|psls|pslc|psss|pssc|psas|psac|psws|pswc|psis|psic|psgs|psgc|pscs|pscc|sbcd|st|sf|shi|sls|scc|shs|scs|slo|sne|seq|svc|svs|spl|smi|sge|slt|sgt|sle|tas|fsf|fseq|fsogt|fsoge|fsolt|fsole|fsogl|fsor|fsun|fsueq|fsugt|fsuge|fsult|fsule|fsne|fst|fssf|fsseq|fsgt|fsge|fslt|fsle|fsgl|fsgle|fsngle|fsngl|fsnle|fsnlt|fsnge|fsngt|fssne|fsst)(\\.[b])?\\b"
+      "match": "(?i)(?<=\\s)(nbcd|abcd|psbs|psbc|psls|pslc|psss|pssc|psas|psac|psws|pswc|psis|psic|psgs|psgc|pscs|pscc|sbcd|st|sf|shi|sls|scc|shs|scs|slo|sne|seq|svc|svs|spl|smi|sge|slt|sgt|sle|tas|fsf|fseq|fsogt|fsoge|fsolt|fsole|fsogl|fsor|fsun|fsueq|fsugt|fsuge|fsult|fsule|fsne|fst|fssf|fsseq|fsgt|fsge|fslt|fsle|fsgl|fsgle|fsngle|fsngl|fsnle|fsnlt|fsnge|fsngt|fssne|fsst)(\\.[b])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.bw.m68k",
-      "match": "(?i)\\b(mvs|mvz)(\\.[bw])?\\b"
+      "match": "(?i)(?<=\\s)(mvs|mvz)(\\.[bw])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.bwld.m68k",
-      "match": "(?i)\\b(pmove)(\\.[bwld])?\\b"
+      "match": "(?i)(?<=\\s)(pmove)(\\.[bwld])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.ldx.m68k",
-      "match": "(?i)\\b(fmovem)(\\.[ldx])?\\b"
+      "match": "(?i)(?<=\\s)(fmovem)(\\.[ldx])?\\b"
     },
     {
       "name": "keyword.other.opcode.fpu.x.m68k",
-      "match": "(?i)\\b(fmovecr)(\\.[x])?\\b"
+      "match": "(?i)(?<=\\s)(fmovecr)(\\.[x])?\\b"
     },
     {
       "name": "keyword.other.opcode.fpu.bwlsdxp.m68k",
-      "match": "(?i)\\b(fabs|fsabs|fdabs|facos|fadd|fsadd|fdadd|fasin|fatan|fatanh|fcmp|fcos|fcosh|fdiv|fsdiv|fddiv|fetox|fetoxm1|fgetexp|fgetman|fint|fintrz|flog10|flog2|flogn|flognp1|fmod|fmove|fsmove|fdmove|fmul|fsmul|fdmul|fneg|fsneg|fdneg|frem|fscale|fsgldiv|fsglmul|fsin|fsinh|fsqrt|fssqrt|fdsqrt|fsub|fssub|fdsub|ftan|ftanh|ftentox|ftwotox)(\\.[bwlsdxp])?\\b"
+      "match": "(?i)(?<=\\s)(fabs|fsabs|fdabs|facos|fadd|fsadd|fdadd|fasin|fatan|fatanh|fcmp|fcos|fcosh|fdiv|fsdiv|fddiv|fetox|fetoxm1|fgetexp|fgetman|fint|fintrz|flog10|flog2|flogn|flognp1|fmod|fmove|fsmove|fdmove|fmul|fsmul|fdmul|fneg|fsneg|fdneg|frem|fscale|fsgldiv|fsglmul|fsin|fsinh|fsqrt|fssqrt|fdsqrt|fsub|fssub|fdsub|ftan|ftanh|ftentox|ftwotox)(\\.[bwlsdxp])?\\b"
     },
     {
       "name": "keyword.other.opcode.mem.m68k",
-      "match": "(?i)\\b(blk|dc|dcb|ds)(\\.[bdlqswx])?\\b"
+      "match": "(?i)(?<=\\s)(blk|dc|dcb|ds)(\\.[bdlqswx])?\\b"
     },
     {
       "name": "keyword.other.opcode.pc.m68k",
-      "match": "(?i)\\b(dr)(\\.[bwl])?\\b"
+      "match": "(?i)(?<=\\s)(dr)(\\.[bwl])?\\b"
     }
   ]
 }

--- a/syntaxes/M68k-Assembly.YAML-tmLanguage
+++ b/syntaxes/M68k-Assembly.YAML-tmLanguage
@@ -63,67 +63,67 @@ patterns:
   match: (?i)\b([ad][0-7]|SP|PC|vbr|fp[0-7])\b
 
 - name: keyword.other.opcode.cpu.bl.m68k
-  match: (?i)\b(bchg|bclr|bset|btst)(\.[bl])?\b
+  match: (?i)(?<=\s)(bchg|bclr|bset|btst)(\.[bl])?\b
 
 - name: keyword.other.opcode.cpu.bwl.m68k
-  match: (?i)\b(lsr|move|tst|moves|wddata|neg|negx|not|or|ori|addq|addi|addx|and|andi|asl|asr|cas|chk2|clr|cmp|cmpi|cmpm|cmp2|eor|eori|rol|ror|roxl|roxr|sub|subi|subq|subx|tbls|tblsn|tblu|tblun|add|lsl)(\.[bwl])?\b
+  match: (?i)(?<=\s)(lsr|move|tst|moves|wddata|neg|negx|not|or|ori|addq|addi|addx|and|andi|asl|asr|cas|chk2|clr|cmp|cmpi|cmpm|cmp2|eor|eori|rol|ror|roxl|roxr|sub|subi|subq|subx|tbls|tblsn|tblu|tblun|add|lsl)(\.[bwl])?\b
 
 - name: keyword.other.opcode.cpu.bwlsdxp.m68k
-  match: (?i)\b(fsincos|ftst)(\.[bwlsdxp])?\b
+  match: (?i)(?<=\s)(fsincos|ftst)(\.[bwlsdxp])?\b
 
 - name: keyword.other.opcode.cpu.wl.m68k
-  match: (?i)\b(maaac|mac|traplo|masac|trapne|trapeq|movea|movem|traple|movep|movm|msaac|msac|mssac|muls|mulu|pbbs|pbbc|adda|pblc|pbss|pbls|pbsc|pbas|pbac|pbws|pbwc|pbis|pbic|pbgs|pbgc|pbcs|pbcc|cas2|chk|cmpa|ptrapbs|ptrapbc|ptrapls|ptraplc|ptrapss|ptrapsc|ptrapas|ptrapac|ptrapws|ptrapwc|ptrapis|divs|ptrapic|ptrapgs|divu|ptrapgc|ptrapcs|ptrapcc|ext|fbf|fbeq|fbogt|fboge|fbolt|fbole|fbogl|fbor|fbun|fbueq|fbugt|fbuge|fbult|fbule|fbne|fbt|fbsf|fbseq|fbgt|fbge|fblt|fble|fbgl|fbgle|suba|fbngle|fbngl|fbnle|fbnlt|fbnge|fbngt|fbsne|fbst|tpf|trapt|trapf|traphi|trapls|trapcc|traphs|trapcs|trapge|trapmi|trappl|trapvs|trapvc|traplt|link|trapgt|ftrapf|ftrapeq|ftrapogt|ftrapoge|ftrapolt|ftrapole|ftrapogl|ftrapor|ftrapun|ftrapueq|ftrapugt|ftrapuge|ftrapult|ftrapule|ftrapne|ftrapt|ftrapsf|ftrapseq|ftrapgt|ftrapge|ftraplt|ftraple|ftrapgl|ftrapgle|ftrapngle|ftrapngl|ftrapnle|ftrapnlt|ftrapnge|ftrapngt|ftrapsne|ftrapst)(\.[wl])?\b
+  match: (?i)(?<=\s)(maaac|mac|traplo|masac|trapne|trapeq|movea|movem|traple|movep|movm|msaac|msac|mssac|muls|mulu|pbbs|pbbc|adda|pblc|pbss|pbls|pbsc|pbas|pbac|pbws|pbwc|pbis|pbic|pbgs|pbgc|pbcs|pbcc|cas2|chk|cmpa|ptrapbs|ptrapbc|ptrapls|ptraplc|ptrapss|ptrapsc|ptrapas|ptrapac|ptrapws|ptrapwc|ptrapis|divs|ptrapic|ptrapgs|divu|ptrapgc|ptrapcs|ptrapcc|ext|fbf|fbeq|fbogt|fboge|fbolt|fbole|fbogl|fbor|fbun|fbueq|fbugt|fbuge|fbult|fbule|fbne|fbt|fbsf|fbseq|fbgt|fbge|fblt|fble|fbgl|fbgle|suba|fbngle|fbngl|fbnle|fbnlt|fbnge|fbngt|fbsne|fbst|tpf|trapt|trapf|traphi|trapls|trapcc|traphs|trapcs|trapge|trapmi|trappl|trapvs|trapvc|traplt|link|trapgt|ftrapf|ftrapeq|ftrapogt|ftrapoge|ftrapolt|ftrapole|ftrapogl|ftrapor|ftrapun|ftrapueq|ftrapugt|ftrapuge|ftrapult|ftrapule|ftrapne|ftrapt|ftrapsf|ftrapseq|ftrapgt|ftrapge|ftraplt|ftraple|ftrapgl|ftrapgle|ftrapngle|ftrapngl|ftrapnle|ftrapnlt|ftrapnge|ftrapngt|ftrapsne|ftrapst)(\.[wl])?\b
 
 - name: keyword.other.opcode.cpu.m68k
-  match: (?i)\b(move16|unlk|unpk|nop|reset|pack|stop|bfchg|pflush|bfclr|pflusha|bfexts|pflushan|bfextu|pflushn|bfffo|pflushr|bfins|pflushs|bfset|ploadr|bftst|ploadw|bgnd|plpar|plpaw|bkpt|callm|prestore|psave|cinvl|cinvp|cinva|cpushl|cpushp|cpusha|ptestr|ptestw|pulse|rtd|rte|rtm|rtr|rts|trap|trapv|fnop|frestore|fsave|halt|illegal|intouch|jmp|jsr|linea|line_a|linef|line_f)\b
+  match: (?i)(?<=\s)(move16|unlk|unpk|nop|reset|pack|stop|bfchg|pflush|bfclr|pflusha|bfexts|pflushan|bfextu|pflushn|bfffo|pflushr|bfins|pflushs|bfset|ploadr|bftst|ploadw|bgnd|plpar|plpaw|bkpt|callm|prestore|psave|cinvl|cinvp|cinva|cpushl|cpushp|cpusha|ptestr|ptestw|pulse|rtd|rte|rtm|rtr|rts|trap|trapv|fnop|frestore|fsave|halt|illegal|intouch|jmp|jsr|linea|line_a|linef|line_f)\b
 
 - name: keyword.other.opcode.cpu.bwls.m68k
-  match: (?i)\b(bhs|blo|bhi|bls|bcc|bcs|bne|beq|bvc|bvs|bpl|bmi|bge|blt|bgt|ble|bra|bsr|jbhs|jblo|jbhi|jbls|jbcc|jbcs|jbne|jbeq|jbvc|jbvs|jbpl|jbmi|jbge|jblt|jbgt|jble|jbra|jbsr)(\.[bwls])?\b
+  match: (?i)(?<=\s)(bhs|blo|bhi|bls|bcc|bcs|bne|beq|bvc|bvs|bpl|bmi|bge|blt|bgt|ble|bra|bsr|jbhs|jblo|jbhi|jbls|jbcc|jbcs|jbne|jbeq|jbvc|jbvs|jbpl|jbmi|jbge|jblt|jbgt|jble|jbra|jbsr)(\.[bwls])?\b
 
 - name: keyword.other.opcode.cpu.ld.m68k
-  match: (?i)\b(pmovefd)(\.[ld])?\b
+  match: (?i)(?<=\s)(pmovefd)(\.[ld])?\b
 
 - name: keyword.other.opcode.cpu.l.m68k
-  match: (?i)\b(mov3q|movclr|movec|moveq|wdebug|pea|bitrev|byterev|divsl|divul|exg|pvalid|rems|extb|remu|sats|ff1|lea)(\.[l])?\b
+  match: (?i)(?<=\s)(mov3q|movclr|movec|moveq|wdebug|pea|bitrev|byterev|divsl|divul|exg|pvalid|rems|extb|remu|sats|ff1|lea)(\.[l])?\b
 
 - name: keyword.other.opcode.cpu.w.m68k
-  match: (?i)\b(lpstop|pdbbs|pdbbc|pdbls|pdblc|pdbss|pdbsc|pdbas|pdbac|pdbws|pdbwc|pdbis|pdbic|pdbgs|pdbgc|pdbcs|pdbcc|dbt|dbf|dbra|dbhi|dbls|dbcc|dbhs|dbcs|dblo|dbne|dbvs|dbeq|dbpl|dbvc|dbmi|dbge|dblt|dbgt|dble|strldsr|swap|fdbf|fdbeq|fdbogt|fdboge|fdbolt|fdbole|fdbogl|fdbor|fdbun|fdbueq|fdbugt|fdbuge|fdbult|fdbule|fdbne|fdbt|fdbsf|fdbseq|fdbgt|fdbge|fdblt|fdble|fdbgl|fdbgle|fdbngle|fdbngl|fdbnle|fdbnlt|fdbnge|fdbngt|fdbsne|fdbst)(\.[w])?\b
+  match: (?i)(?<=\s)(lpstop|pdbbs|pdbbc|pdbls|pdblc|pdbss|pdbsc|pdbas|pdbac|pdbws|pdbwc|pdbis|pdbic|pdbgs|pdbgc|pdbcs|pdbcc|dbt|dbf|dbra|dbhi|dbls|dbcc|dbhs|dbcs|dblo|dbne|dbvs|dbeq|dbpl|dbvc|dbmi|dbge|dblt|dbgt|dble|strldsr|swap|fdbf|fdbeq|fdbogt|fdboge|fdbolt|fdbole|fdbogl|fdbor|fdbun|fdbueq|fdbugt|fdbuge|fdbult|fdbule|fdbne|fdbt|fdbsf|fdbseq|fdbgt|fdbge|fdblt|fdble|fdbgl|fdbgle|fdbngle|fdbngl|fdbnle|fdbnlt|fdbnge|fdbngt|fdbsne|fdbst)(\.[w])?\b
 
 - name: keyword.other.opcode.cpu.b.m68k
-  match: (?i)\b(nbcd|abcd|psbs|psbc|psls|pslc|psss|pssc|psas|psac|psws|pswc|psis|psic|psgs|psgc|pscs|pscc|sbcd|st|sf|shi|sls|scc|shs|scs|slo|sne|seq|svc|svs|spl|smi|sge|slt|sgt|sle|tas|fsf|fseq|fsogt|fsoge|fsolt|fsole|fsogl|fsor|fsun|fsueq|fsugt|fsuge|fsult|fsule|fsne|fst|fssf|fsseq|fsgt|fsge|fslt|fsle|fsgl|fsgle|fsngle|fsngl|fsnle|fsnlt|fsnge|fsngt|fssne|fsst)(\.[b])?\b
+  match: (?i)(?<=\s)(nbcd|abcd|psbs|psbc|psls|pslc|psss|pssc|psas|psac|psws|pswc|psis|psic|psgs|psgc|pscs|pscc|sbcd|st|sf|shi|sls|scc|shs|scs|slo|sne|seq|svc|svs|spl|smi|sge|slt|sgt|sle|tas|fsf|fseq|fsogt|fsoge|fsolt|fsole|fsogl|fsor|fsun|fsueq|fsugt|fsuge|fsult|fsule|fsne|fst|fssf|fsseq|fsgt|fsge|fslt|fsle|fsgl|fsgle|fsngle|fsngl|fsnle|fsnlt|fsnge|fsngt|fssne|fsst)(\.[b])?\b
 
 - name: keyword.other.opcode.cpu.bw.m68k
-  match: (?i)\b(mvs|mvz)(\.[bw])?\b
+  match: (?i)(?<=\s)(mvs|mvz)(\.[bw])?\b
 
 - name: keyword.other.opcode.cpu.bwld.m68k
-  match: (?i)\b(pmove)(\.[bwld])?\b
+  match: (?i)(?<=\s)(pmove)(\.[bwld])?\b
 
 - name: keyword.other.opcode.cpu.ldx.m68k
-  match: (?i)\b(fmovem)(\.[ldx])?\b
+  match: (?i)(?<=\s)(fmovem)(\.[ldx])?\b
 
 - name: keyword.other.opcode.fpu.x.m68k
-  match: (?i)\b(fmovecr)(\.[x])?\b
+  match: (?i)(?<=\s)(fmovecr)(\.[x])?\b
 
 - name: keyword.other.opcode.fpu.bwlsdxp.m68k
-  match: (?i)\b(fabs|fsabs|fdabs|facos|fadd|fsadd|fdadd|fasin|fatan|fatanh|fcmp|fcos|fcosh|fdiv|fsdiv|fddiv|fetox|fetoxm1|fgetexp|fgetman|fint|fintrz|flog10|flog2|flogn|flognp1|fmod|fmove|fsmove|fdmove|fmul|fsmul|fdmul|fneg|fsneg|fdneg|frem|fscale|fsgldiv|fsglmul|fsin|fsinh|fsqrt|fssqrt|fdsqrt|fsub|fssub|fdsub|ftan|ftanh|ftentox|ftwotox)(\.[bwlsdxp])?\b
+  match: (?i)(?<=\s)(fabs|fsabs|fdabs|facos|fadd|fsadd|fdadd|fasin|fatan|fatanh|fcmp|fcos|fcosh|fdiv|fsdiv|fddiv|fetox|fetoxm1|fgetexp|fgetman|fint|fintrz|flog10|flog2|flogn|flognp1|fmod|fmove|fsmove|fdmove|fmul|fsmul|fdmul|fneg|fsneg|fdneg|frem|fscale|fsgldiv|fsglmul|fsin|fsinh|fsqrt|fssqrt|fdsqrt|fsub|fssub|fdsub|ftan|ftanh|ftentox|ftwotox)(\.[bwlsdxp])?\b
 
 - name: keyword.other.opcode.mem.m68k
-  match: (?i)\b(blk|dc|dcb|ds)(\.[bdlqswx])?\b
+  match: (?i)(?<=\s)(blk|dc|dcb|ds)(\.[bdlqswx])?\b
 
 - name: keyword.other.opcode.pc.m68k
-  match: (?i)\b(dr)(\.[bwl])?\b
+  match: (?i)(?<=\s)(dr)(\.[bwl])?\b
 
 - name: keyword.control.import.m68k
-  match: (?i)\b(include|incdir|incbin)\b
+  match: (?i)(?<=\s)(include|incdir|incbin)\b
 
 - name: keyword.control.section.m68k
-  match: (?i)\b(section|bss(_[cf])?|cseg|code(_[cf])?|data(_[cf])?|dseg)\b
+  match: (?i)(?<=\s)(section|bss(_[cf])?|cseg|code(_[cf])?|data(_[cf])?|dseg)\b
 
 - name: keyword.control.condition.m68k
-  match: (?i)\b(if(eq|ne|gt|ge|lt|le|b|nb|c|nc|d|nd|macrod|macrond)|else|end|endif)\b
+  match: (?i)(?<=\s)(if(eq|ne|gt|ge|lt|le|b|nb|c|nc|d|nd|macrod|macrond)|else|end|endif)\b
 
 - name: keyword.control.other.m68k
-  match: (?i)\b(opt|align|cargs|clrfo|clrso|cnop|comm|comment|echo|einline|end[cmfpr]?|erem|even|fail|fpu|idnt|inline|jumpptr|list|llen|load|machine|mexit|mmu|nolist|nopage|nref|odd|offset|opword|org|output|page|plen|print[tv]|public|record|rem|rept|rorg|rsreset|rsset|set|setfo|setso|spc|text|ttl|weak|xdef|xref)\b
+  match: (?i)(?<=\s)(opt|align|cargs|clrfo|clrso|cnop|comm|comment|echo|einline|end[cmfpr]?|erem|even|fail|fpu|idnt|inline|jumpptr|list|llen|load|machine|mexit|mmu|nolist|nopage|nref|odd|offset|opword|org|output|page|plen|print[tv]|public|record|rem|rept|rorg|rsreset|rsset|set|setfo|setso|spc|text|ttl|weak|xdef|xref)\b
 
 - name: keyword.operator.assignment.m68k
   match: (?i)\b(equ(\.[sdxp])|set)\b

--- a/syntaxes/M68k-Assembly.tmLanguage.json
+++ b/syntaxes/M68k-Assembly.tmLanguage.json
@@ -96,87 +96,87 @@
     },
     {
       "name": "keyword.other.opcode.cpu.bl.m68k",
-      "match": "(?i)\\b(bchg|bclr|bset|btst)(\\.[bl])?\\b"
+      "match": "(?i)(?<=\\s)(bchg|bclr|bset|btst)(\\.[bl])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.bwl.m68k",
-      "match": "(?i)\\b(lsr|move|tst|moves|wddata|neg|negx|not|or|ori|addq|addi|addx|and|andi|asl|asr|cas|chk2|clr|cmp|cmpi|cmpm|cmp2|eor|eori|rol|ror|roxl|roxr|sub|subi|subq|subx|tbls|tblsn|tblu|tblun|add|lsl)(\\.[bwl])?\\b"
+      "match": "(?i)(?<=\\s)(lsr|move|tst|moves|wddata|neg|negx|not|or|ori|addq|addi|addx|and|andi|asl|asr|cas|chk2|clr|cmp|cmpi|cmpm|cmp2|eor|eori|rol|ror|roxl|roxr|sub|subi|subq|subx|tbls|tblsn|tblu|tblun|add|lsl)(\\.[bwl])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.bwlsdxp.m68k",
-      "match": "(?i)\\b(fsincos|ftst)(\\.[bwlsdxp])?\\b"
+      "match": "(?i)(?<=\\s)(fsincos|ftst)(\\.[bwlsdxp])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.wl.m68k",
-      "match": "(?i)\\b(maaac|mac|traplo|masac|trapne|trapeq|movea|movem|traple|movep|movm|msaac|msac|mssac|muls|mulu|pbbs|pbbc|adda|pblc|pbss|pbls|pbsc|pbas|pbac|pbws|pbwc|pbis|pbic|pbgs|pbgc|pbcs|pbcc|cas2|chk|cmpa|ptrapbs|ptrapbc|ptrapls|ptraplc|ptrapss|ptrapsc|ptrapas|ptrapac|ptrapws|ptrapwc|ptrapis|divs|ptrapic|ptrapgs|divu|ptrapgc|ptrapcs|ptrapcc|ext|fbf|fbeq|fbogt|fboge|fbolt|fbole|fbogl|fbor|fbun|fbueq|fbugt|fbuge|fbult|fbule|fbne|fbt|fbsf|fbseq|fbgt|fbge|fblt|fble|fbgl|fbgle|suba|fbngle|fbngl|fbnle|fbnlt|fbnge|fbngt|fbsne|fbst|tpf|trapt|trapf|traphi|trapls|trapcc|traphs|trapcs|trapge|trapmi|trappl|trapvs|trapvc|traplt|link|trapgt|ftrapf|ftrapeq|ftrapogt|ftrapoge|ftrapolt|ftrapole|ftrapogl|ftrapor|ftrapun|ftrapueq|ftrapugt|ftrapuge|ftrapult|ftrapule|ftrapne|ftrapt|ftrapsf|ftrapseq|ftrapgt|ftrapge|ftraplt|ftraple|ftrapgl|ftrapgle|ftrapngle|ftrapngl|ftrapnle|ftrapnlt|ftrapnge|ftrapngt|ftrapsne|ftrapst)(\\.[wl])?\\b"
+      "match": "(?i)(?<=\\s)(maaac|mac|traplo|masac|trapne|trapeq|movea|movem|traple|movep|movm|msaac|msac|mssac|muls|mulu|pbbs|pbbc|adda|pblc|pbss|pbls|pbsc|pbas|pbac|pbws|pbwc|pbis|pbic|pbgs|pbgc|pbcs|pbcc|cas2|chk|cmpa|ptrapbs|ptrapbc|ptrapls|ptraplc|ptrapss|ptrapsc|ptrapas|ptrapac|ptrapws|ptrapwc|ptrapis|divs|ptrapic|ptrapgs|divu|ptrapgc|ptrapcs|ptrapcc|ext|fbf|fbeq|fbogt|fboge|fbolt|fbole|fbogl|fbor|fbun|fbueq|fbugt|fbuge|fbult|fbule|fbne|fbt|fbsf|fbseq|fbgt|fbge|fblt|fble|fbgl|fbgle|suba|fbngle|fbngl|fbnle|fbnlt|fbnge|fbngt|fbsne|fbst|tpf|trapt|trapf|traphi|trapls|trapcc|traphs|trapcs|trapge|trapmi|trappl|trapvs|trapvc|traplt|link|trapgt|ftrapf|ftrapeq|ftrapogt|ftrapoge|ftrapolt|ftrapole|ftrapogl|ftrapor|ftrapun|ftrapueq|ftrapugt|ftrapuge|ftrapult|ftrapule|ftrapne|ftrapt|ftrapsf|ftrapseq|ftrapgt|ftrapge|ftraplt|ftraple|ftrapgl|ftrapgle|ftrapngle|ftrapngl|ftrapnle|ftrapnlt|ftrapnge|ftrapngt|ftrapsne|ftrapst)(\\.[wl])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.m68k",
-      "match": "(?i)\\b(move16|unlk|unpk|nop|reset|pack|stop|bfchg|pflush|bfclr|pflusha|bfexts|pflushan|bfextu|pflushn|bfffo|pflushr|bfins|pflushs|bfset|ploadr|bftst|ploadw|bgnd|plpar|plpaw|bkpt|callm|prestore|psave|cinvl|cinvp|cinva|cpushl|cpushp|cpusha|ptestr|ptestw|pulse|rtd|rte|rtm|rtr|rts|trap|trapv|fnop|frestore|fsave|halt|illegal|intouch|jmp|jsr|linea|line_a|linef|line_f)\\b"
+      "match": "(?i)(?<=\\s)(move16|unlk|unpk|nop|reset|pack|stop|bfchg|pflush|bfclr|pflusha|bfexts|pflushan|bfextu|pflushn|bfffo|pflushr|bfins|pflushs|bfset|ploadr|bftst|ploadw|bgnd|plpar|plpaw|bkpt|callm|prestore|psave|cinvl|cinvp|cinva|cpushl|cpushp|cpusha|ptestr|ptestw|pulse|rtd|rte|rtm|rtr|rts|trap|trapv|fnop|frestore|fsave|halt|illegal|intouch|jmp|jsr|linea|line_a|linef|line_f)\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.bwls.m68k",
-      "match": "(?i)\\b(bhs|blo|bhi|bls|bcc|bcs|bne|beq|bvc|bvs|bpl|bmi|bge|blt|bgt|ble|bra|bsr|jbhs|jblo|jbhi|jbls|jbcc|jbcs|jbne|jbeq|jbvc|jbvs|jbpl|jbmi|jbge|jblt|jbgt|jble|jbra|jbsr)(\\.[bwls])?\\b"
+      "match": "(?i)(?<=\\s)(bhs|blo|bhi|bls|bcc|bcs|bne|beq|bvc|bvs|bpl|bmi|bge|blt|bgt|ble|bra|bsr|jbhs|jblo|jbhi|jbls|jbcc|jbcs|jbne|jbeq|jbvc|jbvs|jbpl|jbmi|jbge|jblt|jbgt|jble|jbra|jbsr)(\\.[bwls])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.ld.m68k",
-      "match": "(?i)\\b(pmovefd)(\\.[ld])?\\b"
+      "match": "(?i)(?<=\\s)(pmovefd)(\\.[ld])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.l.m68k",
-      "match": "(?i)\\b(mov3q|movclr|movec|moveq|wdebug|pea|bitrev|byterev|divsl|divul|exg|pvalid|rems|extb|remu|sats|ff1|lea)(\\.[l])?\\b"
+      "match": "(?i)(?<=\\s)(mov3q|movclr|movec|moveq|wdebug|pea|bitrev|byterev|divsl|divul|exg|pvalid|rems|extb|remu|sats|ff1|lea)(\\.[l])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.w.m68k",
-      "match": "(?i)\\b(lpstop|pdbbs|pdbbc|pdbls|pdblc|pdbss|pdbsc|pdbas|pdbac|pdbws|pdbwc|pdbis|pdbic|pdbgs|pdbgc|pdbcs|pdbcc|dbt|dbf|dbra|dbhi|dbls|dbcc|dbhs|dbcs|dblo|dbne|dbvs|dbeq|dbpl|dbvc|dbmi|dbge|dblt|dbgt|dble|strldsr|swap|fdbf|fdbeq|fdbogt|fdboge|fdbolt|fdbole|fdbogl|fdbor|fdbun|fdbueq|fdbugt|fdbuge|fdbult|fdbule|fdbne|fdbt|fdbsf|fdbseq|fdbgt|fdbge|fdblt|fdble|fdbgl|fdbgle|fdbngle|fdbngl|fdbnle|fdbnlt|fdbnge|fdbngt|fdbsne|fdbst)(\\.[w])?\\b"
+      "match": "(?i)(?<=\\s)(lpstop|pdbbs|pdbbc|pdbls|pdblc|pdbss|pdbsc|pdbas|pdbac|pdbws|pdbwc|pdbis|pdbic|pdbgs|pdbgc|pdbcs|pdbcc|dbt|dbf|dbra|dbhi|dbls|dbcc|dbhs|dbcs|dblo|dbne|dbvs|dbeq|dbpl|dbvc|dbmi|dbge|dblt|dbgt|dble|strldsr|swap|fdbf|fdbeq|fdbogt|fdboge|fdbolt|fdbole|fdbogl|fdbor|fdbun|fdbueq|fdbugt|fdbuge|fdbult|fdbule|fdbne|fdbt|fdbsf|fdbseq|fdbgt|fdbge|fdblt|fdble|fdbgl|fdbgle|fdbngle|fdbngl|fdbnle|fdbnlt|fdbnge|fdbngt|fdbsne|fdbst)(\\.[w])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.b.m68k",
-      "match": "(?i)\\b(nbcd|abcd|psbs|psbc|psls|pslc|psss|pssc|psas|psac|psws|pswc|psis|psic|psgs|psgc|pscs|pscc|sbcd|st|sf|shi|sls|scc|shs|scs|slo|sne|seq|svc|svs|spl|smi|sge|slt|sgt|sle|tas|fsf|fseq|fsogt|fsoge|fsolt|fsole|fsogl|fsor|fsun|fsueq|fsugt|fsuge|fsult|fsule|fsne|fst|fssf|fsseq|fsgt|fsge|fslt|fsle|fsgl|fsgle|fsngle|fsngl|fsnle|fsnlt|fsnge|fsngt|fssne|fsst)(\\.[b])?\\b"
+      "match": "(?i)(?<=\\s)(nbcd|abcd|psbs|psbc|psls|pslc|psss|pssc|psas|psac|psws|pswc|psis|psic|psgs|psgc|pscs|pscc|sbcd|st|sf|shi|sls|scc|shs|scs|slo|sne|seq|svc|svs|spl|smi|sge|slt|sgt|sle|tas|fsf|fseq|fsogt|fsoge|fsolt|fsole|fsogl|fsor|fsun|fsueq|fsugt|fsuge|fsult|fsule|fsne|fst|fssf|fsseq|fsgt|fsge|fslt|fsle|fsgl|fsgle|fsngle|fsngl|fsnle|fsnlt|fsnge|fsngt|fssne|fsst)(\\.[b])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.bw.m68k",
-      "match": "(?i)\\b(mvs|mvz)(\\.[bw])?\\b"
+      "match": "(?i)(?<=\\s)(mvs|mvz)(\\.[bw])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.bwld.m68k",
-      "match": "(?i)\\b(pmove)(\\.[bwld])?\\b"
+      "match": "(?i)(?<=\\s)(pmove)(\\.[bwld])?\\b"
     },
     {
       "name": "keyword.other.opcode.cpu.ldx.m68k",
-      "match": "(?i)\\b(fmovem)(\\.[ldx])?\\b"
+      "match": "(?i)(?<=\\s)(fmovem)(\\.[ldx])?\\b"
     },
     {
       "name": "keyword.other.opcode.fpu.x.m68k",
-      "match": "(?i)\\b(fmovecr)(\\.[x])?\\b"
+      "match": "(?i)(?<=\\s)(fmovecr)(\\.[x])?\\b"
     },
     {
       "name": "keyword.other.opcode.fpu.bwlsdxp.m68k",
-      "match": "(?i)\\b(fabs|fsabs|fdabs|facos|fadd|fsadd|fdadd|fasin|fatan|fatanh|fcmp|fcos|fcosh|fdiv|fsdiv|fddiv|fetox|fetoxm1|fgetexp|fgetman|fint|fintrz|flog10|flog2|flogn|flognp1|fmod|fmove|fsmove|fdmove|fmul|fsmul|fdmul|fneg|fsneg|fdneg|frem|fscale|fsgldiv|fsglmul|fsin|fsinh|fsqrt|fssqrt|fdsqrt|fsub|fssub|fdsub|ftan|ftanh|ftentox|ftwotox)(\\.[bwlsdxp])?\\b"
+      "match": "(?i)(?<=\\s)(fabs|fsabs|fdabs|facos|fadd|fsadd|fdadd|fasin|fatan|fatanh|fcmp|fcos|fcosh|fdiv|fsdiv|fddiv|fetox|fetoxm1|fgetexp|fgetman|fint|fintrz|flog10|flog2|flogn|flognp1|fmod|fmove|fsmove|fdmove|fmul|fsmul|fdmul|fneg|fsneg|fdneg|frem|fscale|fsgldiv|fsglmul|fsin|fsinh|fsqrt|fssqrt|fdsqrt|fsub|fssub|fdsub|ftan|ftanh|ftentox|ftwotox)(\\.[bwlsdxp])?\\b"
     },
     {
       "name": "keyword.other.opcode.mem.m68k",
-      "match": "(?i)\\b(blk|dc|dcb|ds)(\\.[bdlqswx])?\\b"
+      "match": "(?i)(?<=\\s)(blk|dc|dcb|ds)(\\.[bdlqswx])?\\b"
     },
     {
       "name": "keyword.other.opcode.pc.m68k",
-      "match": "(?i)\\b(dr)(\\.[bwl])?\\b"
+      "match": "(?i)(?<=\\s)(dr)(\\.[bwl])?\\b"
     },
     {
       "name": "keyword.control.import.m68k",
-      "match": "(?i)\\b(include|incdir|incbin)\\b"
+      "match": "(?i)(?<=\\s)(include|incdir|incbin)\\b"
     },
     {
       "name": "keyword.control.section.m68k",
-      "match": "(?i)\\b(section|bss(_[cf])?|cseg|code(_[cf])?|data(_[cf])?|dseg)\\b"
+      "match": "(?i)(?<=\\s)(section|bss(_[cf])?|cseg|code(_[cf])?|data(_[cf])?|dseg)\\b"
     },
     {
       "name": "keyword.control.condition.m68k",
-      "match": "(?i)\\b(if(eq|ne|gt|ge|lt|le|b|nb|c|nc|d|nd|macrod|macrond)|else|end|endif)\\b"
+      "match": "(?i)(?<=\\s)(if(eq|ne|gt|ge|lt|le|b|nb|c|nc|d|nd|macrod|macrond)|else|end|endif)\\b"
     },
     {
       "name": "keyword.control.other.m68k",
-      "match": "(?i)\\b(opt|align|cargs|clrfo|clrso|cnop|comm|comment|echo|einline|end[cmfpr]?|erem|even|fail|fpu|idnt|inline|jumpptr|list|llen|load|machine|mexit|mmu|nolist|nopage|nref|odd|offset|opword|org|output|page|plen|print[tv]|public|record|rem|rept|rorg|rsreset|rsset|set|setfo|setso|spc|text|ttl|weak|xdef|xref)\\b"
+      "match": "(?i)(?<=\\s)(opt|align|cargs|clrfo|clrso|cnop|comm|comment|echo|einline|end[cmfpr]?|erem|even|fail|fpu|idnt|inline|jumpptr|list|llen|load|machine|mexit|mmu|nolist|nopage|nref|odd|offset|opword|org|output|page|plen|print[tv]|public|record|rem|rept|rorg|rsreset|rsset|set|setfo|setso|spc|text|ttl|weak|xdef|xref)\\b"
     },
     {
       "name": "keyword.operator.assignment.m68k",


### PR DESCRIPTION
This addresses a problem where the parser misinterprets labels containing opcode names and causes the formatter to output invalid code.

Fixes #179