### PR TITLE
Provide completion for labels

### DIFF
--- a/src/definitionHandler.ts
+++ b/src/definitionHandler.ts
@@ -430,5 +430,21 @@ export class M68kDefinitionHandler implements DefinitionProvider, ReferenceProvi
         }
         return values;
     }
+
+    /**
+     * Find all the labels starting by word
+     * @param word Word to search
+     * @return labels found.
+     */
+    findLabelStartingWith(word: string): Map<string, string | undefined> {
+        const values = new Map<string, string | undefined>();
+        const upper = word.toUpperCase();
+        for (const [key, value] of this.labels.entries()) {
+            if (key.toUpperCase().startsWith(upper)) {
+                values.set(key, value.getValue());
+            }
+        }
+        return values;
+    }
 }
 

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -80,6 +80,28 @@ describe("Completion Tests", function () {
             const elm = results[0];
             expect(elm.label).to.be.equal("MY_W_VAR");
         });
+        it("Should return a completion on a label", async function () {
+            const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());
+            const document = new DummyTextDocument();
+            const position: Position = new Position(0, 7);
+            const tokenEmitter = new CancellationTokenSource();
+            document.addLine(" jsr Mai");
+            const results = await cp.provideCompletionItems(document, position, tokenEmitter.token);
+            expect(results).to.not.be.undefined;
+            const elm = results[0];
+            expect(elm.label).to.be.equal("Main");
+        });
+        it("Should return a completion on a local label", async function () {
+            const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());
+            const document = new DummyTextDocument();
+            const position: Position = new Position(0, 11);
+            const tokenEmitter = new CancellationTokenSource();
+            document.addLine(" jsr .chkmo");
+            const results = await cp.provideCompletionItems(document, position, tokenEmitter.token);
+            expect(results).to.not.be.undefined;
+            const elm = results[0];
+            expect(elm.label).to.be.equal(".chkmouse");
+        });
         it("Should return a completion on an instruction", async function () {
             const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());
             const document = new DummyTextDocument();


### PR DESCRIPTION
Provide completions for labels as well as variables from the current workspace.

Includes support for local names with a dot prefix. This is a bit of a pain as by default vscode uses `document.getWordRangeAtPosition()` to find the boundaries of the word being completed. This treats `.` as a separator and not part of the word, so we need to adjust the range and apply it to the `CompletionItem`.