### PR TITLE
Preserve case of completions

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -51,13 +51,21 @@ export class M68kCompletionItemProvider implements vscode.CompletionItemProvider
                                 continue;
                             } else {
                                 if (value.type === DocumentationType.REGISTER) {
+                                    if (word[0] === word[0].toLowerCase()) {
+                                        label = label.toLowerCase()
+                                    }
                                     kind = vscode.CompletionItemKind.Variable;
                                 } else if (word.startsWith("_LVO")) {
                                     label = "_LVO" + label;
                                 }
                             }
-                        } else if (!isMnemonic) {
-                            continue;
+                        } else {
+                            if (!isMnemonic) {
+                                continue;
+                            }
+                            if (word[0] === word[0].toUpperCase()) {
+                                label = label.toUpperCase()
+                            }
                         }
                         const completion = new vscode.CompletionItem(label, kind);
                         completion.documentation = new vscode.MarkdownString(value.description);
@@ -98,10 +106,12 @@ export class M68kCompletionItemProvider implements vscode.CompletionItemProvider
         } else if ((lastChar === ".") && asmLine.instructionRange.contains(position.translate(undefined, -1))) {
             const localRange = document.getWordRangeAtPosition(position.translate(undefined, -1));
             const word = document.getText(localRange);
-            const extensions = this.language.getExtensions(word);
+            const extensions = this.language.getExtensions(word.toLowerCase());
+            const isUpper = word === word.toUpperCase();
             if (extensions) {
-                for (const ext of extensions) {
-                    const completion = new vscode.CompletionItem(ext, vscode.CompletionItemKind.Unit);
+                for (let ext of extensions) {
+                    const text = isUpper ? ext.toUpperCase() : ext;
+                    const completion = new vscode.CompletionItem(text, vscode.CompletionItemKind.Unit);
                     completions.push(completion);
                 }
             }

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -69,6 +69,17 @@ describe("Completion Tests", function () {
             const elm = results[0];
             expect(elm.label).to.be.equal("INTENAR");
         });
+        it("Should preserve case on completion of a register", async function () {
+            const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());
+            const document = new DummyTextDocument();
+            const position: Position = new Position(0, 11);
+            const tokenEmitter = new CancellationTokenSource();
+            document.addLine(" move.l inten");
+            const results = await cp.provideCompletionItems(document, position, tokenEmitter.token);
+            expect(results).to.not.be.undefined;
+            const elm = results[0];
+            expect(elm.label).to.be.equal("intenar");
+        });
         it("Should return a completion on a variable", async function () {
             const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());
             const document = new DummyTextDocument();
@@ -113,6 +124,17 @@ describe("Completion Tests", function () {
             const elm = results[0];
             expect(elm.label).to.be.equal("move");
         });
+        it("Should preserve case on completion of an instruction", async function () {
+            const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());
+            const document = new DummyTextDocument();
+            const position: Position = new Position(0, 3);
+            const tokenEmitter = new CancellationTokenSource();
+            document.addLine(" MOV");
+            const results = await cp.provideCompletionItems(document, position, tokenEmitter.token);
+            expect(results.length).to.be.equal(5);
+            const elm = results[0];
+            expect(elm.label).to.be.equal("MOVE");
+        });
         it("Should return a completion on a directive", async function () {
             const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());
             const document = new DummyTextDocument();
@@ -137,6 +159,16 @@ describe("Completion Tests", function () {
             document.addLine(" move.l");
             results = await cp.provideCompletionItems(document, position, tokenEmitter.token);
             expect(results).to.be.empty;
+        });
+        it("Should match case of size completions to instruction", async function () {
+            const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());
+            const document = new DummyTextDocument();
+            let position = new Position(0, 6);
+            const tokenEmitter = new CancellationTokenSource();
+            document.addLine(" MOVE.");
+            let results = await cp.provideCompletionItems(document, position, tokenEmitter.token);
+            const elm = results[0];
+            expect(elm.label).to.be.equal("B");
         });
         it("Should not return completion in a comment", async function () {
             const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());


### PR DESCRIPTION
Matches case to user input on completion of registers and instructions.

Registers may be either upper or lower case depending on the includes used. NDK uses lower case but people often use upper-cased versions e.g. with `hw.i`. Documentation is in upper case so completions are currently always upper case, which is not what you want if you're using standard NDK includes. New behaviour is to match the case of the user input being completed e.g. `inte` -> `intena`, `INTE` -> `INTENA`.

Instruction mnemonics are not case sensitive in assembly and are purely a matter of coding style so it would be good not to force our preferences on the user. Current behaviour always completes to lower case. Apply the same logic here to match input case e.g. `mov` -> `move`, `MOV` -> `MOVE`.

Instruction size suffixes should match the case of the instruction e.g. `MOVE.` -> `MOVE.B`.