### PR TITLE
Handle local labels correctly

### DIFF
--- a/src/hover.ts
+++ b/src/hover.ts
@@ -51,16 +51,25 @@ export class M68kHoverProvider implements vscode.HoverProvider {
         } else if (asmLine.dataRange && asmLine.dataRange.contains(position)) {
             // get the word
             let word = document.getWordRangeAtPosition(position);
+            let prefix = "";
             if (word) {
-                // Extend range to include leading dot
                 if (line.text.charAt(word.start.character -1) === '.') {
+                    // Extend range to include leading dot
                     word = new vscode.Range(
                         new vscode.Position(word.start.line, word.start.character - 1),
                         word.end
                     )
+                    // Find previous global label
+                    for (let i = word.start.line; i >= 0; i--) {
+                        const match = document.lineAt(i).text.match(/^(\w+)\b/);
+                        if (match) {
+                            prefix = match[0];
+                            break;
+                        }
+                    }
                 }
                 // Text to search in
-                let text = document.getText(word);
+                let text = prefix + document.getText(word);
                 let rendered = await this.renderWordHover(text.toUpperCase());
                 let renderedLine2 = null;
                 if (!rendered) {

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -46,14 +46,20 @@ export class SymbolFile {
             }
             const instruct = asmLine.instruction.toLowerCase();
             if (asmLine.label.length > 0) {
-                const label = asmLine.label.replace(":", "");
+                let label = asmLine.label.replace(":", "");
+                const isLocal = label.indexOf(".") === 0;
+                if (isLocal) {
+                    label = lastLabel?.getLabel() + label;
+                }
                 const s = new Symbol(label, this, asmLine.labelRange);
                 // Is this actually a macro definition in `<name> macro` syntax?
                 if (instruct.indexOf("macro") === 0) {
                     this.macros.push(s);
                 } else {
                     this.labels.push(s);
-                    lastLabel = s;
+                    if (!isLocal) {
+                        lastLabel = s;
+                    }
                 }
             } else if (instruct.indexOf("macro") === 0) {
                 // Handle ` macro <name>` syntax

--- a/src/test/dummy.ts
+++ b/src/test/dummy.ts
@@ -17,8 +17,7 @@ export class DummyTextDocument implements TextDocument {
     lineCount = 0;
     lines = new Array<TextLine>();
     public addLine(line: string) {
-        const newLine = new DummyTextLine(line);
-        newLine.lineNumber = this.lineCount;
+        const newLine = new DummyTextLine(line, this.lineCount);
         this.lines.push(newLine);
         this.lineCount += 1;
     }
@@ -145,9 +144,10 @@ export class DummyTextLine implements TextLine {
     rangeIncludingLineBreak: Range = new Range(new Position(0, 0), new Position(0, 1));
     firstNonWhitespaceCharacterIndex = 1;
     isEmptyOrWhitespace = false;
-    constructor(text: string) {
+    constructor(text: string, lineNumber: number = 0) {
         this.text = text;
-        this.range = new Range(new Position(0, 0), new Position(0, text.length));
+        this.range = new Range(new Position(lineNumber, 0), new Position(lineNumber, text.length));
+        this.lineNumber = lineNumber;
     }
 }
 


### PR DESCRIPTION
All labels are currently treated as unique global symbols and are suggested as completions anywhere in the project.

Labels with a dot prefix are contextual to their parent label. The same local label name can be defined multiple times in different contexts. It only makes sense to offer local labels as a completion when in the relevant scope.

The simplest solution for all of this is to prefix local labels when defining and looking up symbols, effectively name-spacing them to their parent label.

e.g.
```assembly
Main:
.example
```
would be stored internally as `Main.example`