### PR TITLE
Fix: Don't complete prefixed local labels

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -94,9 +94,11 @@ export class M68kCompletionItemProvider implements vscode.CompletionItemProvider
                         // In the current symbols
                         const labels = this.definitionHandler.findLabelStartingWith(word);
                         for (const [label, symbol] of labels.entries()) {
-                            if (!labelsAdded.includes(label)) {
+                            const unPrefixed = label.substring(prefix.length);
+                            const isLocalFQ = unPrefixed.match(/.\./);
+                            if (!labelsAdded.includes(label) && !isLocalFQ) {
                                 const kind = vscode.CompletionItemKind.Function;
-                                const completion = new vscode.CompletionItem(label.substring(prefix.length), kind);
+                                const completion = new vscode.CompletionItem(unPrefixed, kind);
                                 const filename = symbol.getFile().getUri().path.split("/").pop();
                                 const line = symbol.getRange().start.line;
                                 completion.detail =  "label " + filename + ":" + line;

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -152,6 +152,19 @@ describe("Completion Tests", function () {
             const elm = results.find(n => n.label === '.example')!;
             expect(elm).to.be.undefined;
         });
+        it("Should not return prefixed local labels", async function () {
+            const document = new DummyTextDocument();
+            const position: Position = new Position(2, 10);
+            const tokenEmitter = new CancellationTokenSource();
+            document.addLine("Example:");
+            document.addLine(".example");
+            document.addLine(" jsr Exampl");
+            const definitionHandler = state.getDefinitionHandler();
+            await definitionHandler.scanFile(document.uri, document);
+            const cp = new M68kCompletionItemProvider(documentationManager, definitionHandler, await state.getLanguage());
+            const results = await cp.provideCompletionItems(document, position, tokenEmitter.token);
+            expect(results).to.have.lengthOf(1);
+        });
         it("Should return a completion on an instruction", async function () {
             const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());
             const document = new DummyTextDocument();


### PR DESCRIPTION
Fix unintended side effect of local labels solution. Make sure the internal prefixed full name of a local label is never provided as a completion.

e.g. `Examp` -> `Example.localLabel`