### PR TITLE
Add xref symbols for completion/hover

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -111,6 +111,16 @@ export class M68kCompletionItemProvider implements vscode.CompletionItemProvider
                                 labelsAdded.push(label);
                             }
                         }
+                        const xrefs = this.definitionHandler.findXrefStartingWith(word);
+                        for (const [xref] of xrefs.entries()) {
+                            if (!labelsAdded.includes(xref)) {
+                                const kind = vscode.CompletionItemKind.Function;
+                                const completion = new vscode.CompletionItem(xref, kind);
+                                completion.detail =  "xref";
+                                completions.push(completion);
+                                labelsAdded.push(xref);
+                            }
+                        }
                         const variables = this.definitionHandler.findVariableStartingWith(word);
                         for (const [variable, symbol] of variables.entries()) {
                             if (!labelsAdded.includes(variable)) {

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -81,16 +81,18 @@ export class M68kHoverProvider implements vscode.HoverProvider {
                 let rendered = await this.renderWordHover(text.toUpperCase());
                 let renderedLine2 = null;
                 if (!rendered) {
-                    const [cpuReg, label] = await Promise.all([
+                    const [cpuReg, label, xref] = await Promise.all([
                         this.documentationManager.getCpuRegister(text.toUpperCase()),
-                        definitionHandler.getLabelByName(text)
+                        definitionHandler.getLabelByName(text),
+                        definitionHandler.getXrefByName(text)
                     ]);
                     if (cpuReg) {
                         rendered = new vscode.MarkdownString(cpuReg.detail);
-                    } else if (label) {
+                    } else if (label || xref) {
+                        const symbol = label || xref;
                         const info = new vscode.MarkdownString();
-                        info.appendCodeblock("(label) " + label.getLabel());
-                        const description = label.getCommentBlock();
+                        info.appendCodeblock("(label) " + symbol!.getLabel());
+                        const description = symbol!.getCommentBlock();
                         if (description) {
                             rendered = new vscode.MarkdownString();
                             rendered.appendText(description);

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -11,6 +11,7 @@ export class SymbolFile {
     private variables = new Array<Symbol>();
     private labels = new Array<Symbol>();
     private macros = new Array<Symbol>();
+    private xrefs = new Array<Symbol>();
     private subroutines = new Array<string>();
     private dcLabel = new Array<Symbol>();
     private includeDirs = new Array<Symbol>();
@@ -58,16 +59,22 @@ export class SymbolFile {
                 // Is this actually a macro definition in `<name> macro` syntax?
                 if (instruct.indexOf("macro") === 0) {
                     this.macros.push(s);
+                    this.definedSymbols.push(s);
                 } else {
                     this.labels.push(s);
                     if (!isLocal) {
                         lastLabel = s;
                     }
                 }
+            } else if (instruct.indexOf("xref") === 0) {
+                const s = new Symbol(asmLine.data, this, asmLine.dataRange);
+                this.xrefs.push(s);
+                this.definedSymbols.push(s);
             } else if (instruct.indexOf("macro") === 0) {
                 // Handle ` macro <name>` syntax
                 const s = new Symbol(asmLine.data, this, asmLine.dataRange);
                 this.macros.push(s);
+                this.definedSymbols.push(s);
             }
             if (asmLine.variable.length > 0) {
                 this.variables.push(new Symbol(asmLine.variable, this, asmLine.variableRange, asmLine.value));
@@ -115,6 +122,7 @@ export class SymbolFile {
         this.variables = new Array<Symbol>();
         this.labels = new Array<Symbol>();
         this.macros = new Array<Symbol>();
+        this.xrefs = new Array<Symbol>();
         this.subroutines = new Array<string>();
         this.dcLabel = new Array<Symbol>();
         this.includeDirs = new Array<Symbol>();
@@ -138,6 +146,9 @@ export class SymbolFile {
     }
     public getMacros(): Array<Symbol> {
         return this.macros;
+    }
+    public getXrefs(): Array<Symbol> {
+        return this.xrefs;
     }
     public getSubRoutines(): Array<string> {
         return this.subroutines;

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -211,9 +211,22 @@ describe("Completion Tests", function () {
             document.addLine(" mac");
             const results = await cp.provideCompletionItems(document, position, tokenEmitter.token);
             const elm = results.find(e => e.label === "macro1")!;
-            expect(elm).to.not.be.empty;
+            expect(elm).to.not.be.undefined;
             expect(elm.detail).to.be.equal("macro");
             expect(elm.documentation).to.contain("<name> MACRO");
+        });
+        it("Should return a completion on a xref", async function () {
+            const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());
+            const document = new DummyTextDocument();
+            const position: Position = new Position(1, 10);
+            const tokenEmitter = new CancellationTokenSource();
+            document.addLine(" xref MyXref");
+            document.addLine(" bsr MyXre");
+            await dHnd.scanFile(document.uri, document);
+            const results = await cp.provideCompletionItems(document, position, tokenEmitter.token);
+            const elm = results.find(e => e.label === "MyXref")!;
+            expect(elm).to.not.be.undefined;
+            expect(elm.detail).to.be.equal("xref");
         });
         it("Should not return a completion on an instruction after .", async function () {
             const cp = new M68kCompletionItemProvider(documentationManager, state.getDefinitionHandler(), await state.getLanguage());

--- a/src/test/symbols.test.ts
+++ b/src/test/symbols.test.ts
@@ -19,7 +19,7 @@ describe("Symbols reader Tests", function () {
         const variables = symbolFile.getVariables();
         const labels = symbolFile.getLabels();
         const macros = symbolFile.getMacros();
-        expect(definedSymbols.length).to.be.equal(61);
+        expect(definedSymbols.length).to.be.equal(63);
         const referedSymbols = symbolFile.getReferredSymbols();
         expect(referedSymbols.length).to.be.equal(318);
         const firstDefined = definedSymbols[2];


### PR DESCRIPTION
xrefs are essentially labels referenced from a linked object rather than an inlcuded source file. We should track their definition and references and they should work like labels for the purposes of completion and hover behaviour.