### PR TITLE
Improve outline by setting label ranges

### DIFF
--- a/src/definitionHandler.ts
+++ b/src/definitionHandler.ts
@@ -31,13 +31,27 @@ export class M68kDefinitionHandler implements DefinitionProvider, ReferenceProvi
             for (let i = 0; i < symbols.length; i++) {
                 const symbol = symbols[i];
                 let symbolKind = vscode.SymbolKind.Function;
-                if (symbolFile.getSubRoutines().indexOf(symbol.getLabel()) >= 0) {
+                let isLocal = symbol.getLabel().includes(".");
+                let label = symbol.getLabel().replace(/.+\./, ".");
+                if (symbolFile.getSubRoutines().indexOf(label) >= 0) {
                     symbolKind = vscode.SymbolKind.Class;
                 } else if (symbolFile.getDcLabels().indexOf(symbol) >= 0) {
                     symbolKind = vscode.SymbolKind.Variable;
                 }
-                if (symbol.getLabel()) {
-                    results.push(new SymbolInformation(symbol.getLabel(), symbolKind, symbol.getParent(), new Location(symbol.getFile().getUri(), symbol.getRange())));
+                if (label) {
+                    // Extend range to next label:
+                    let nextLabel: Symbol | null = null;
+                    for (let j = i + 1; j < symbols.length; j++) {
+                        const l = symbols[j];
+                        // Next global label unless current label is local
+                        if (isLocal || !l.getLabel().includes(".")) {
+                            nextLabel = l;
+                            break;
+                        }
+                    }
+                    const end = nextLabel?.getRange().start ?? document.lineAt(document.lineCount -1).range.end;
+                    const range = new Range(symbol.getRange().start, end);
+                    results.push(new SymbolInformation(label, symbolKind, symbol.getParent(), new Location(symbol.getFile().getUri(), range)));
                 }
             }
             const includedFiles = symbolFile.getIncludedFiles();


### PR DESCRIPTION
By extending the range of label symbols we get a more representative outline showing the hierarchy of global / local labels.

<img width="445" alt="image" src="https://user-images.githubusercontent.com/1519709/148542385-92d22ae2-09b9-4ebd-95bf-adc8204e9d1b.png">
