### PR TITLE
feat: Substitute variables in config args

### DIFF
--- a/src/adf.ts
+++ b/src/adf.ts
@@ -5,6 +5,7 @@ import { VASMCompiler } from "./vasm";
 import { FileProxy } from "./fsProxy";
 import { ExtensionState } from "./extension";
 import { ConfigurationHelper } from "./configurationHelper";
+import { substituteVariables } from "./configVariables";
 
 /**
  * Definition of the adf properties
@@ -80,7 +81,7 @@ export class ADFTools {
         }
         const includes = conf.includes;
         const excludes = conf.excludes;
-        const adfCreateOptions = conf.adfCreateOptions;
+        const adfCreateOptions = conf.adfCreateOptions.map(a => substituteVariables(a, true));
         let bootBlockSourceFileName;
         if (conf.bootBlockSourceFile) {
             bootBlockSourceFileName = conf.bootBlockSourceFile;

--- a/src/configVariables.ts
+++ b/src/configVariables.ts
@@ -1,0 +1,140 @@
+import * as vscode from "vscode";
+import * as path from "path";
+
+interface Context {
+  workspaceFolders?: vscode.WorkspaceFolder[];
+  activeTextEditor?: vscode.TextEditor;
+  configuration?: vscode.WorkspaceConfiguration;
+  environmentVariables?: Record<string, string>;
+}
+
+/**
+ * Expand variable tokens in a config string.
+ *
+ * @see {@link https://code.visualstudio.com/docs/editor/variables-reference|Variables reference}
+ *
+ * The built-in logic in vscode only applies to specific properties and is not currently exposed in the public API
+ * https://github.com/Microsoft/vscode/issues/46471
+ *
+ * For now we need to re-create the behaviour in order to apply it to custom properties.
+ *
+ * Supported variables:
+ * - ${env:Name} - environment variable
+ * - ${config:Name} - configuration key name
+ * - ${workspaceFolder} - the path of the folder opened in VS Code
+ * - ${workspaceFolderBasename} - the name of the folder opened in VS Code without any slashes (/)
+ * - ${file} - the current opened file
+ * - ${fileWorkspaceFolder} - the current opened file's workspace folder
+ * - ${relativeFile} - the current opened file relative to workspaceFolder
+ * - ${relativeFileDirname} - the current opened file's dirname relative to workspaceFolder
+ * - ${fileBasename} - the current opened file's basename
+ * - ${fileBasenameNoExtension} - the current opened file's basename with no file extension
+ * - ${fileDirname} - the current opened file's dirname
+ * - ${fileExtname} - the current opened file's extension
+ * - ${cwd} - current working directory
+ * - ${lineNumber} - the current selected line number in the active file
+ * - ${selectedText} - the current selected text in the active file
+ * - ${pathSeparator} - the character used by the operating system to separate components in file paths
+ *
+ * @param str String to process
+ * @param recursive Apply substitutions recursively?
+ * @param ctx Context
+ *
+ * @return Processed string
+ */
+export function substituteVariables(
+  str: string,
+  recursive = false,
+  ctx?: Context
+) {
+  // Allow context to be set explicitly for testing, default to global state.
+  const workspaceFolders =
+    ctx?.workspaceFolders ?? vscode.workspace.workspaceFolders;
+  const activeTextEditor =
+    ctx?.activeTextEditor ?? vscode.window.activeTextEditor;
+  const configuration =
+    ctx?.configuration ?? vscode.workspace.getConfiguration();
+  const environmentVariables = ctx?.environmentVariables ?? process.env;
+
+  const workspace = workspaceFolders?.[0];
+  const activeFile = activeTextEditor?.document;
+  const file = activeFile?.uri.fsPath;
+  const parsedPath = file ? path.parse(file) : undefined;
+
+  // Find the workspace which contains the active file and get the relative path
+  let relativeFile = file;
+  let activeWorkspace = workspace;
+  if (file && workspaceFolders) {
+    for (const ws of workspaceFolders) {
+      if (file.startsWith(ws.uri.fsPath)) {
+        activeWorkspace = ws;
+        relativeFile = file.replace(ws.uri.fsPath, "").substr(path.sep.length);
+        break;
+      }
+    }
+  }
+
+  // Predefined replacements:
+  const replacements: Record<string, string | undefined> = {
+    workspaceFolder: workspace?.uri.fsPath,
+    workspaceFolderBasename: workspace?.name,
+    file,
+    fileBasename: parsedPath?.base,
+    fileBasenameNoExtension: parsedPath?.name,
+    fileDirname: parsedPath?.dir.substr(
+      parsedPath.dir.lastIndexOf(path.sep) + 1
+    ),
+    fileExtname: parsedPath?.ext,
+    cwd: parsedPath?.dir,
+    fileWorkspaceFolder: activeWorkspace?.uri.fsPath,
+    relativeFile,
+    relativeFileDirname: relativeFile?.substr(
+      0,
+      relativeFile.lastIndexOf(path.sep)
+    ),
+    lineNumber: activeTextEditor
+      ? String(activeTextEditor.selection.start.line + 1)
+      : "",
+    selectedText: activeTextEditor?.document.getText(
+      new vscode.Range(
+        activeTextEditor.selection.start,
+        activeTextEditor.selection.end
+      )
+    ),
+    pathSeparator: path.sep,
+  };
+
+  let key: keyof typeof replacements;
+  for (key in replacements) {
+    const pattern = new RegExp("\\${" + key + "}", "g");
+    str = str.replace(pattern, replacements[key] ?? "");
+  }
+
+  // Environment variables:
+  str = str.replace(/\${env:(.*?)}/g, (variable) => {
+    const varName = variable.match(/\${env:(.*?)}/)?.[1];
+    return varName ? environmentVariables[varName] ?? "" : "";
+  });
+
+  // Config keys:
+  str = str.replace(/\${config:(.*?)}/g, (variable) => {
+    const varName = variable.match(/\${config:(.*?)}/)?.[1];
+    return varName ? configuration.get(varName, "") : "";
+  });
+
+  // Apply recursive replacements if enabled and string still contains any variables
+  if (
+    recursive &&
+    str.match(
+      new RegExp(
+        "\\${(" +
+          Object.keys(replacements).join("|") +
+          "|env:(.*?)|config:(.*?))}"
+      )
+    )
+  ) {
+    str = substituteVariables(str, recursive, ctx);
+  }
+
+  return str;
+}

--- a/src/fsUAEDebug.ts
+++ b/src/fsUAEDebug.ts
@@ -21,6 +21,7 @@ import { CopperDisassembler } from './copperDisassembler';
 import { FileProxy } from './fsProxy';
 import { VariableDisplayFormat, VariableDisplayFormatRequest, VariableFormatter } from './variableFormatter';
 import { ConfigurationHelper } from './configurationHelper';
+import { substituteVariables } from './configVariables';
 
 /**
  * This interface describes the mock-debug specific launch attributes
@@ -469,10 +470,11 @@ export class FsUAEDebugSession extends DebugSession implements DebugVariableReso
                 if (await this.checkEmulator(emulatorExe)) {
                     this.cancellationTokenSource = new CancellationTokenSource();
                     let emulatorWorkingDir = args.emulatorWorkingDir || null;
+                    const options = args.options.map(a => substituteVariables(a, true))
                     if (emulatorWorkingDir) {
                         emulatorWorkingDir = ConfigurationHelper.replaceBinDirVariable(emulatorWorkingDir);
                     }
-                    this.executor.runTool(args.options, emulatorWorkingDir, "warning", true, emulatorExe, null, true, null, this.cancellationTokenSource.token).then(() => {
+                    this.executor.runTool(options, emulatorWorkingDir, "warning", true, emulatorExe, null, true, null, this.cancellationTokenSource.token).then(() => {
                         this.sendEvent(new TerminatedEvent());
                     }).catch(err => {
                         this.sendEvent(new TerminatedEvent());

--- a/src/runFsUAENoDebug.ts
+++ b/src/runFsUAENoDebug.ts
@@ -10,6 +10,7 @@ import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
 import { CancellationTokenSource, window, Uri } from 'vscode';
 import { ExecutorHelper } from './execHelper';
 import { FileProxy } from './fsProxy';
+import { substituteVariables } from './configVariables';
 
 /**
  * This interface describes the mock-debug specific launch attributes
@@ -109,12 +110,13 @@ export class RunFsUAENoDebugSession extends DebugSession {
 		logger.warn("Starting emulator: " + args.emulator);
 		const emulatorExe = args.emulator;
 		const emulatorWorkingDir = args.emulatorWorkingDir || null;
+		const options = args.options.map((a) => substituteVariables(a, true));
 		if (emulatorExe) {
 			// Is the emulator exe present in the filesystem ?
 			if (await this.checkEmulator(emulatorExe)) {
 				this.cancellationTokenSource = new CancellationTokenSource();
 				try {
-					await this.executor.runTool(args.options, emulatorWorkingDir, "warning", true, emulatorExe, null, true, null, this.cancellationTokenSource.token);
+					await this.executor.runTool(options, emulatorWorkingDir, "warning", true, emulatorExe, null, true, null, this.cancellationTokenSource.token);
 					this.sendEvent(new TerminatedEvent());
 				} catch (err) {
 					throw new Error(`Error raised by the emulator run: ${err.message}`);

--- a/src/test/configVariables.test.ts
+++ b/src/test/configVariables.test.ts
@@ -1,0 +1,364 @@
+import { substituteVariables } from "../configVariables";
+import * as vscode from "vscode";
+import * as path from "path";
+import { expect } from "chai";
+
+describe("configVariables", () => {
+  describe("substituteVariables", () => {
+    it("leaves text unchanged", () => {
+      const str = "foo";
+      const result = substituteVariables(str);
+      expect(result).to.equal(str);
+    });
+
+    it("replaces env vars", () => {
+      const str = "foo ${env:example} baz";
+      const result = substituteVariables(str, true, {
+        environmentVariables: { example: "bar" },
+      });
+      expect(result).to.equal("foo bar baz");
+    });
+
+    it("removes missing env vars", () => {
+      const str = "foo  baz";
+      const result = substituteVariables(str, true, {
+        environmentVariables: {},
+      });
+      expect(result).to.equal("foo  baz");
+    });
+
+    it("replaces config vars", () => {
+      const str = "foo ${config:example} baz";
+      const configuration = new Map<string, string>([["example", "bar"]]);
+      const result = substituteVariables(str, true, {
+        configuration:
+          configuration as unknown as vscode.WorkspaceConfiguration,
+      });
+      expect(result).to.equal("foo bar baz");
+    });
+
+    it("replaces workspaceFolder", () => {
+      const str = "foo ${workspaceFolder} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+        ],
+      });
+      expect(result).to.equal("foo /example/dir baz");
+    });
+
+    it("replaces workspaceFolderBasename", () => {
+      const str = "foo ${workspaceFolderBasename} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+        ],
+      });
+      expect(result).to.equal("foo dir baz");
+    });
+
+    it("replaces file", () => {
+      const str = "foo ${file} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+        ],
+        activeTextEditor: {
+          document: {
+            uri: vscode.Uri.file("/example/dir/file.s"),
+            getText: () => "",
+          } as unknown as vscode.TextDocument,
+          selection: new vscode.Selection(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 0)
+          ),
+        } as unknown as vscode.TextEditor,
+      });
+      expect(result).to.equal("foo /example/dir/file.s baz");
+    });
+
+    it("replaces fileWorkspaceFolder", () => {
+      const str = "foo ${fileWorkspaceFolder} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+          {
+            uri: vscode.Uri.file("/example2"),
+            name: "example2",
+            index: 0,
+          },
+        ],
+        activeTextEditor: {
+          document: {
+            uri: vscode.Uri.file("/example2/file.s"),
+            getText: () => "",
+          } as unknown as vscode.TextDocument,
+          selection: new vscode.Selection(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 0)
+          ),
+        } as unknown as vscode.TextEditor,
+      });
+      expect(result).to.equal("foo /example2 baz");
+    });
+
+    it("replaces relativeFile", () => {
+      const str = "foo ${relativeFile} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+          {
+            uri: vscode.Uri.file("/example2"),
+            name: "example2",
+            index: 1,
+          },
+        ],
+        activeTextEditor: {
+          document: {
+            uri: vscode.Uri.file("/example2/file.s"),
+            getText: () => "",
+          } as unknown as vscode.TextDocument,
+          selection: new vscode.Selection(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 0)
+          ),
+        } as unknown as vscode.TextEditor,
+      });
+      expect(result).to.equal("foo file.s baz");
+    });
+
+    it("replaces relativeFileDirname", () => {
+      const str = "foo ${relativeFileDirname} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+          {
+            uri: vscode.Uri.file("/example2"),
+            name: "example2",
+            index: 1,
+          },
+        ],
+        activeTextEditor: {
+          document: {
+            uri: vscode.Uri.file("/example2/dir/file.s"),
+            getText: () => "",
+          } as unknown as vscode.TextDocument,
+          selection: new vscode.Selection(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 0)
+          ),
+        } as unknown as vscode.TextEditor,
+      });
+      expect(result).to.equal("foo dir baz");
+    });
+
+    it("replaces fileBasename", () => {
+      const str = "foo ${fileBasename} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+        ],
+        activeTextEditor: {
+          document: {
+            uri: vscode.Uri.file("/example/dir/file.s"),
+            getText: () => "",
+          } as unknown as vscode.TextDocument,
+          selection: new vscode.Selection(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 0)
+          ),
+        } as unknown as vscode.TextEditor,
+      });
+      expect(result).to.equal("foo file.s baz");
+    });
+
+    it("replaces fileBasenameNoExtension", () => {
+      const str = "foo ${fileBasenameNoExtension} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+        ],
+        activeTextEditor: {
+          document: {
+            uri: vscode.Uri.file("/example/dir/file.s"),
+            getText: () => "",
+          } as unknown as vscode.TextDocument,
+          selection: new vscode.Selection(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 0)
+          ),
+        } as unknown as vscode.TextEditor,
+      });
+      expect(result).to.equal("foo file baz");
+    });
+
+    it("replaces fileDirname", () => {
+      const str = "foo ${fileDirname} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+        ],
+        activeTextEditor: {
+          document: {
+            uri: vscode.Uri.file("/example/dir/file.s"),
+            getText: () => "",
+          } as unknown as vscode.TextDocument,
+          selection: new vscode.Selection(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 0)
+          ),
+        } as unknown as vscode.TextEditor,
+      });
+      expect(result).to.equal("foo dir baz");
+    });
+
+    it("replaces fileExtname", () => {
+      const str = "foo ${fileExtname} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+        ],
+        activeTextEditor: {
+          document: {
+            uri: vscode.Uri.file("/example/dir/file.s"),
+            getText: () => "",
+          } as unknown as vscode.TextDocument,
+          selection: new vscode.Selection(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 0)
+          ),
+        } as unknown as vscode.TextEditor,
+      });
+      expect(result).to.equal("foo .s baz");
+    });
+
+    it("replaces cwd", () => {
+      const str = "foo ${cwd} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+        ],
+        activeTextEditor: {
+          document: {
+            uri: vscode.Uri.file("/example/dir/file.s"),
+            getText: () => "",
+          } as unknown as vscode.TextDocument,
+          selection: new vscode.Selection(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 0)
+          ),
+        } as unknown as vscode.TextEditor,
+      });
+      expect(result).to.equal("foo /example/dir baz");
+    });
+
+    it("replaces lineNumber", () => {
+      const str = "foo ${lineNumber} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+        ],
+        activeTextEditor: {
+          document: {
+            uri: vscode.Uri.file("/example/dir/file.s"),
+            getText: () => "",
+          } as unknown as vscode.TextDocument,
+          selection: new vscode.Selection(
+            new vscode.Position(1, 0),
+            new vscode.Position(1, 0)
+          ),
+        } as unknown as vscode.TextEditor,
+      });
+      expect(result).to.equal("foo 2 baz");
+    });
+
+    it("replaces selectedText", () => {
+      const str = "foo ${selectedText} baz";
+      const result = substituteVariables(str, true, {
+        workspaceFolders: [
+          {
+            uri: vscode.Uri.file("/example/dir"),
+            name: "dir",
+            index: 0,
+          },
+        ],
+        activeTextEditor: {
+          document: {
+            uri: vscode.Uri.file("/example/dir/file.s"),
+            getText: () => "selected text",
+          } as unknown as vscode.TextDocument,
+          selection: new vscode.Selection(
+            new vscode.Position(1, 0),
+            new vscode.Position(1, 10)
+          ),
+        } as unknown as vscode.TextEditor,
+      });
+      expect(result).to.equal("foo selected text baz");
+    });
+
+    it("replaces pathSeparator", () => {
+      const str = "foo ${pathSeparator} baz";
+      const result = substituteVariables(str, true, {});
+      expect(result).to.equal(`foo ${path.sep} baz`);
+    });
+
+    it("replaces recursively", () => {
+      const str = "foo ${env:example} baz";
+      const result = substituteVariables(str, true, {
+        environmentVariables: {
+          example: "${env:example2}",
+          example2: "${pathSeparator}",
+        },
+      });
+      expect(result).to.equal(`foo ${path.sep} baz`);
+    });
+  });
+});

--- a/src/vasm.ts
+++ b/src/vasm.ts
@@ -14,6 +14,7 @@ import * as path from "path";
 import * as winston from 'winston';
 import { FileProxy } from "./fsProxy";
 import { ConfigurationHelper } from "./configurationHelper";
+import { substituteVariables } from "./configVariables";
 
 /**
  * Definition of the vasm build properties
@@ -388,7 +389,7 @@ export class VASMCompiler {
         }
         let confArgs = new Array<string>();
         if (conf.args && (conf.args.length > 0)) {
-          confArgs = conf.args;
+          confArgs = conf.args.map((a) => substituteVariables(a, true));
         }
         const args: Array<string> = confArgs.concat(["-o", objFilename, fileUri.fsPath]);
         errorDiagnosticCollection.delete(fileUri);

--- a/src/vlink.ts
+++ b/src/vlink.ts
@@ -2,6 +2,7 @@ import { Uri, EventEmitter } from "vscode";
 import { ExecutorParser, ICheckResult, ExecutorHelper } from "./execHelper";
 import * as path from "path";
 import { ConfigurationHelper } from "./configurationHelper";
+import { substituteVariables } from "./configVariables";
 
 /**
  * Definition of the vlink properties
@@ -67,7 +68,7 @@ export class VLINKLinker {
      */
     public async linkFiles(conf: VlinkBuildProperties, filesURI: Uri[], exeFilepathname: string, entrypoint: string | undefined, workspaceRootDir: Uri, buildDir: Uri, logEmitter?: EventEmitter<string>): Promise<ICheckResult[]> {
         const vlinkExecutableName: string = ConfigurationHelper.replaceBinDirVariable(conf.command);
-        const confArgs = conf.args;
+        const confArgs = conf.args.map(a => substituteVariables(a, true));
         const objectPathNames: string[] = [];
         for (let i = 0; i < filesURI.length; i += 1) {
             const filename = path.basename(filesURI[i].fsPath);


### PR DESCRIPTION
Prompted by a [query on EAB](https://eab.abime.net/showpost.php?p=1543766&postcount=300), it's not currently possible to use dynamic values such as environment variables in custom properties for task or debug config. According to the [VS Code docs](https://code.visualstudio.com/docs/editor/variables-reference#_why-arent-variables-in-tasksjson-being-resolved) this is expected behaviour and variables are only expanded in a limited set of core properties.

I'd hoped that there would be an API to expose the core substitution behavour so extensions could apply it elsewhere. It turns out [I'm not alone in this hope](https://github.com/Microsoft/vscode/issues/46471), but it's not currently possible. The workaround for now is to reimplement the core behaviour. There is an npm module mentioned in that thread, but it's currently lacking types and various null checks so I've just put the logic in the extension. This could eventually be removed if MS respond to the feature request and expose a public API.

I've applied the substitutions where I could see it makes sense but there may be other places it could be used. @prb28 let me know if you're happy in applying this feature and if so I'll add some tests.