### PR TITLE
fix: Remove `.only` qualifier on test

### DIFF
--- a/src/test/workspaceManager.test.ts
+++ b/src/test/workspaceManager.test.ts
@@ -9,7 +9,7 @@ import { WorkspaceManager } from '../workspaceManager';
 import { ExtensionState } from '../extension';
 chai.use(chaiAsPromised);
 
-describe.only("WorkspaceManager test", function () {
+describe("WorkspaceManager test", function () {
     before(async function () {
         // Automatically track and cleanup files at exit
         temp.track();


### PR DESCRIPTION
This was preventing other tests from running. 

At $DAYJOB we use [eslint-plugin-mocha-no-only](https://www.npmjs.com/package/eslint-plugin-mocha-no-only) to catch these as it happens a lot!