### PR TITLE
feat: variable substitution on additional props

### DIFF
--- a/src/adf.ts
+++ b/src/adf.ts
@@ -4,7 +4,6 @@ import * as path from 'path';
 import { VASMCompiler } from "./vasm";
 import { FileProxy } from "./fsProxy";
 import { ExtensionState } from "./extension";
-import { ConfigurationHelper } from "./configurationHelper";
 import { substituteVariables } from "./configVariables";
 
 /**
@@ -49,7 +48,7 @@ export class ADFTools {
      */
     public constructor(adfToolsRootPath: string) {
         this.executor = new ExecutorHelper();
-        this.setToolsRootPath(ConfigurationHelper.replaceBinDirVariable(adfToolsRootPath));
+        this.setToolsRootPath(substituteVariables(adfToolsRootPath, true));
     }
 
     /**
@@ -71,20 +70,20 @@ export class ADFTools {
      * @param cancellationToken Token to cancel the process
      */
     public async createBootableADFDisk(conf: AdfGeneratorProperties, logEmitter?: EventEmitter<string>, compiler?: VASMCompiler, cancellationToken?: CancellationToken): Promise<void> {
-        this.setToolsRootPath(ConfigurationHelper.replaceBinDirVariable(conf.ADFToolsParentDir));
-        const filename = conf.outputADFFile;
+        this.setToolsRootPath(substituteVariables(conf.ADFToolsParentDir, true));
+        const filename = substituteVariables(conf.outputADFFile, true);
         let rootSourceDir = "";
         if (conf.sourceRootDir) {
-            rootSourceDir = conf.sourceRootDir;
+            rootSourceDir = substituteVariables(conf.sourceRootDir, true);
         } else {
             throw new Error("Please configure de sourceRootDir of the ADF file generator");
         }
-        const includes = conf.includes;
-        const excludes = conf.excludes;
+        const includes = substituteVariables(conf.includes, true);
+        const excludes = substituteVariables(conf.excludes, true);
         const adfCreateOptions = conf.adfCreateOptions.map(a => substituteVariables(a, true));
         let bootBlockSourceFileName;
         if (conf.bootBlockSourceFile) {
-            bootBlockSourceFileName = conf.bootBlockSourceFile;
+            bootBlockSourceFileName = substituteVariables(conf.bootBlockSourceFile, true);
         }
         await this.createBootableADFDiskFromDir(filename, rootSourceDir, includes, excludes, adfCreateOptions, bootBlockSourceFileName, logEmitter, compiler, cancellationToken);
     }

--- a/src/configurationHelper.ts
+++ b/src/configurationHelper.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import winston = require('winston');
+import { substituteVariables } from './configVariables';
 import { FileProxy } from './fsProxy';
 export class ConfigurationHelper {
     public static readonly CONFIGURATION_NAME = 'amiga-assembly';
@@ -107,25 +108,8 @@ export class ConfigurationHelper {
         const configuration = ConfigurationHelper.getDefaultConfiguration(null);
         const confValue = configuration.get<string>(key);
         if (confValue) {
-            return ConfigurationHelper.replaceBinDirVariable(confValue);
+            return substituteVariables(confValue, true);
         }
         return undefined;
-    }
-
-    /**
-     * 
-     * @param value Replaces a variable with the binaries directory path
-     * @returns Replaced value or undefined
-     */
-    public static replaceBinDirVariable(value: string): string {
-        const configuration = ConfigurationHelper.getDefaultConfiguration(null);
-        let binariesPath = configuration.get<string>(ConfigurationHelper.BINARIES_PATH_KEY);
-        if (ConfigurationHelper.BINARY_PATH) {
-            binariesPath = ConfigurationHelper.BINARY_PATH;
-        }
-        if (binariesPath) {
-            return value.replace("${config:amiga-assembly.binDir}", binariesPath);
-        }
-        return value;
     }
 }

--- a/src/fsUAEDebug.ts
+++ b/src/fsUAEDebug.ts
@@ -465,14 +465,14 @@ export class FsUAEDebugSession extends DebugSession implements DebugVariableReso
         if (args.startEmulator) {
             this.sendEvent(new OutputEvent(`Starting emulator: ${args.emulator}`));
             if (args.emulator) {
-                const emulatorExe = ConfigurationHelper.replaceBinDirVariable(args.emulator);
+                const emulatorExe = substituteVariables(args.emulator, true);
                 // Is the emulator exe present in the filesystem ?
                 if (await this.checkEmulator(emulatorExe)) {
                     this.cancellationTokenSource = new CancellationTokenSource();
                     let emulatorWorkingDir = args.emulatorWorkingDir || null;
                     const options = args.options.map(a => substituteVariables(a, true))
                     if (emulatorWorkingDir) {
-                        emulatorWorkingDir = ConfigurationHelper.replaceBinDirVariable(emulatorWorkingDir);
+                        emulatorWorkingDir = substituteVariables(emulatorWorkingDir, true);
                     }
                     this.executor.runTool(options, emulatorWorkingDir, "warning", true, emulatorExe, null, true, null, this.cancellationTokenSource.token).then(() => {
                         this.sendEvent(new TerminatedEvent());

--- a/src/test/workspaceManager.test.ts
+++ b/src/test/workspaceManager.test.ts
@@ -9,7 +9,7 @@ import { WorkspaceManager } from '../workspaceManager';
 import { ExtensionState } from '../extension';
 chai.use(chaiAsPromised);
 
-describe.only("WorkspaceManager test", function () {
+describe("WorkspaceManager test", function () {
     before(async function () {
         // Automatically track and cleanup files at exit
         temp.track();

--- a/src/vasm.ts
+++ b/src/vasm.ts
@@ -376,7 +376,7 @@ export class VASMCompiler {
         const state = ExtensionState.getCurrent();
         const warningDiagnosticCollection = state.getWarningDiagnosticCollection();
         const errorDiagnosticCollection = state.getErrorDiagnosticCollection();
-        const vasmExecutableName: string = ConfigurationHelper.replaceBinDirVariable(conf.command);
+        const vasmExecutableName: string = substituteVariables(conf.command, true);
         const extSep = filename.indexOf(".");
         let objFilename: string;
         if (extSep > 0) {

--- a/src/vlink.ts
+++ b/src/vlink.ts
@@ -1,7 +1,6 @@
 import { Uri, EventEmitter } from "vscode";
 import { ExecutorParser, ICheckResult, ExecutorHelper } from "./execHelper";
 import * as path from "path";
-import { ConfigurationHelper } from "./configurationHelper";
 import { substituteVariables } from "./configVariables";
 
 /**
@@ -67,7 +66,11 @@ export class VLINKLinker {
      * @param logEmitter Log emitter
      */
     public async linkFiles(conf: VlinkBuildProperties, filesURI: Uri[], exeFilepathname: string, entrypoint: string | undefined, workspaceRootDir: Uri, buildDir: Uri, logEmitter?: EventEmitter<string>): Promise<ICheckResult[]> {
-        const vlinkExecutableName: string = ConfigurationHelper.replaceBinDirVariable(conf.command);
+        exeFilepathname = substituteVariables(exeFilepathname, true);
+        if (entrypoint) {
+          entrypoint = substituteVariables(entrypoint, true);
+        }
+        const vlinkExecutableName: string = substituteVariables(conf.command, true);
         const confArgs = conf.args.map(a => substituteVariables(a, true));
         const objectPathNames: string[] = [];
         for (let i = 0; i < filesURI.length; i += 1) {


### PR DESCRIPTION
I've applied the new `substituteVariables` function to a few more properties.

It looks like we no longer need `ConfigurationHelper.replaceBinDirVariable()` as `binDir` will be replaced by `substituteVariables` along with other config keys. I went ahead and swapped it out but there does appear to be a special case that I'm not too clear on:

It looks like if there's an error setting the `binDir` config key the value is stored in the static `ConfigurationHelper.BINARY_PATH`, which is used instead:

```typescript
            try {
                await ConfigurationHelper.updateProperty(ConfigurationHelper.BINARIES_PATH_KEY, binariesPath, vscode.ConfigurationTarget.Global);
            } catch (error) {
                ConfigurationHelper.BINARY_PATH = binariesPath;
            }
```

Can you remember why this would happen and if it's something that still needs to be handled?

