### PR TITLE
Update uae-dap, remove variable formats

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14,7 +14,7 @@
 				"extract-zip": "^2.0.1",
 				"glob": "^7.2.0",
 				"rimraf": "^3.0.2",
-				"uae-dap": "^0.6.0",
+				"uae-dap": "^0.7.0",
 				"uuid": "^8.3.2",
 				"vscode-debugadapter": "^1.51.0",
 				"vscode-debugprotocol": "^1.51.0",
@@ -3996,9 +3996,9 @@
 			}
 		},
 		"node_modules/uae-dap": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-0.6.0.tgz",
-			"integrity": "sha512-Cs525WHuUkdZt7UemmDgCZX7WNAUxcSa1I9nMsKpaEBVGX3dmaB9zUEiqRcmj3JuZCBG6hQQLXLMAXK7zDC0vQ==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-0.7.0.tgz",
+			"integrity": "sha512-g76Ysk0tMrgSa2nVlqce6txCa99M4XB8OJ9EyQNl+6d59WJhs3p2oAjyZHmUgTepWK8mkK20exLTuYPut6SRSg==",
 			"dependencies": {
 				"@vscode/debugadapter": "^1.55.1",
 				"@vscode/debugprotocol": "^1.55.1",
@@ -7475,9 +7475,9 @@
 			"dev": true
 		},
 		"uae-dap": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-0.6.0.tgz",
-			"integrity": "sha512-Cs525WHuUkdZt7UemmDgCZX7WNAUxcSa1I9nMsKpaEBVGX3dmaB9zUEiqRcmj3JuZCBG6hQQLXLMAXK7zDC0vQ==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-0.7.0.tgz",
+			"integrity": "sha512-g76Ysk0tMrgSa2nVlqce6txCa99M4XB8OJ9EyQNl+6d59WJhs3p2oAjyZHmUgTepWK8mkK20exLTuYPut6SRSg==",
 			"requires": {
 				"@vscode/debugadapter": "^1.55.1",
 				"@vscode/debugprotocol": "^1.55.1",

--- a/package.json
+++ b/package.json
@@ -290,51 +290,11 @@
 			},
 			{
 				"command": "amiga-assembly.showVariableAsDec",
-				"title": "View as Decimal (unsigned longword)"
-			},
-			{
-				"command": "amiga-assembly.showVariableAsDecSigned",
-				"title": "View as Decimal (signed longword)"
-			},
-			{
-				"command": "amiga-assembly.showVariableAsDecWord",
-				"title": "View as Decimal (unsigned word)"
-			},
-			{
-				"command": "amiga-assembly.showVariableAsDecWordSigned",
-				"title": "View as Decimal (signed word)"
-			},
-			{
-				"command": "amiga-assembly.showVariableAsDecByte",
-				"title": "View as Decimal (unsigned byte)"
-			},
-			{
-				"command": "amiga-assembly.showVariableAsDecByteSigned",
-				"title": "View as Decimal (signed byte)"
+				"title": "View as Decimal"
 			},
 			{
 				"command": "amiga-assembly.showVariableAsHex",
-				"title": "View as Hex (unsigned longword)"
-			},
-			{
-				"command": "amiga-assembly.showVariableAsHexSigned",
-				"title": "View as Hex (signed longword)"
-			},
-			{
-				"command": "amiga-assembly.showVariableAsHexWord",
-				"title": "View as Hex (unsigned word)"
-			},
-			{
-				"command": "amiga-assembly.showVariableAsHexWordSigned",
-				"title": "View as Hex (signed word)"
-			},
-			{
-				"command": "amiga-assembly.showVariableAsHexByte",
-				"title": "View as Hex (unsigned byte)"
-			},
-			{
-				"command": "amiga-assembly.showVariableAsHexByteSigned",
-				"title": "View as Hex (signed byte)"
+				"title": "View as Hex"
 			},
 			{
 				"command": "amiga-assembly.showVariableAsBin",
@@ -816,67 +776,17 @@
 				{
 					"command": "amiga-assembly.showVariableAsDec",
 					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@1"
-				},
-				{
-					"command": "amiga-assembly.showVariableAsDecSigned",
-					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@2"
-				},
-				{
-					"command": "amiga-assembly.showVariableAsDecWord",
-					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@3"
-				},
-				{
-					"command": "amiga-assembly.showVariableAsDecWordSigned",
-					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@4"
-				},
-				{
-					"command": "amiga-assembly.showVariableAsDecByte",
-					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@5"
-				},
-				{
-					"command": "amiga-assembly.showVariableAsDecByteSigned",
-					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@6"
+					"group": "1_view"
 				},
 				{
 					"command": "amiga-assembly.showVariableAsHex",
 					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@7"
-				},
-				{
-					"command": "amiga-assembly.showVariableAsHexSigned",
-					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@8"
-				},
-				{
-					"command": "amiga-assembly.showVariableAsHexWord",
-					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@9"
-				},
-				{
-					"command": "amiga-assembly.showVariableAsHexWordSigned",
-					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@10"
-				},
-				{
-					"command": "amiga-assembly.showVariableAsHexByte",
-					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@11"
-				},
-				{
-					"command": "amiga-assembly.showVariableAsHexByteSigned",
-					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@12"
+					"group": "1_view"
 				},
 				{
 					"command": "amiga-assembly.showVariableAsBin",
 					"when": "debugType == 'winuae' || debugType == 'fs-uae'",
-					"group": "1_view@13"
+					"group": "1_view"
 				}
 			]
 		},
@@ -1088,7 +998,7 @@
 		"extract-zip": "^2.0.1",
 		"glob": "^7.2.0",
 		"rimraf": "^3.0.2",
-		"uae-dap": "^0.6.0",
+		"uae-dap": "^0.7.0",
 		"uuid": "^8.3.2",
 		"vscode-debugadapter": "^1.51.0",
 		"vscode-debugprotocol": "^1.51.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -554,48 +554,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         setDisplayFormat(variableInfo, NumberFormat.DECIMAL);
     });
     context.subscriptions.push(disposable);
-    disposable = vscode.commands.registerCommand('amiga-assembly.showVariableAsDecSigned', (variableInfo) => {
-        setDisplayFormat(variableInfo, NumberFormat.DECIMAL_SIGNED);
-    });
-    context.subscriptions.push(disposable);
-    disposable = vscode.commands.registerCommand('amiga-assembly.showVariableAsDecWord', (variableInfo) => {
-        setDisplayFormat(variableInfo, NumberFormat.DECIMAL_WORD);
-    });
-    context.subscriptions.push(disposable);
-    disposable = vscode.commands.registerCommand('amiga-assembly.showVariableAsDecWordSigned', (variableInfo) => {
-        setDisplayFormat(variableInfo, NumberFormat.DECIMAL_WORD_SIGNED);
-    });
-    context.subscriptions.push(disposable);
-    disposable = vscode.commands.registerCommand('amiga-assembly.showVariableAsDecByte', (variableInfo) => {
-        setDisplayFormat(variableInfo, NumberFormat.DECIMAL_BYTE);
-    });
-    context.subscriptions.push(disposable);
-    disposable = vscode.commands.registerCommand('amiga-assembly.showVariableAsDecByteSigned', (variableInfo) => {
-        setDisplayFormat(variableInfo, NumberFormat.DECIMAL_BYTE_SIGNED);
-    });
-    context.subscriptions.push(disposable);
     disposable = vscode.commands.registerCommand('amiga-assembly.showVariableAsHex', (variableInfo) => {
         setDisplayFormat(variableInfo, NumberFormat.HEXADECIMAL);
-    });
-    context.subscriptions.push(disposable);
-    disposable = vscode.commands.registerCommand('amiga-assembly.showVariableAsHexSigned', (variableInfo) => {
-        setDisplayFormat(variableInfo, NumberFormat.HEXADECIMAL_SIGNED);
-    });
-    context.subscriptions.push(disposable);
-    disposable = vscode.commands.registerCommand('amiga-assembly.showVariableAsHexWord', (variableInfo) => {
-        setDisplayFormat(variableInfo, NumberFormat.HEXADECIMAL_WORD);
-    });
-    context.subscriptions.push(disposable);
-    disposable = vscode.commands.registerCommand('amiga-assembly.showVariableAsHexWordSigned', (variableInfo) => {
-        setDisplayFormat(variableInfo, NumberFormat.HEXADECIMAL_WORD_SIGNED);
-    });
-    context.subscriptions.push(disposable);
-    disposable = vscode.commands.registerCommand('amiga-assembly.showVariableAsHexByte', (variableInfo) => {
-        setDisplayFormat(variableInfo, NumberFormat.HEXADECIMAL_BYTE);
-    });
-    context.subscriptions.push(disposable);
-    disposable = vscode.commands.registerCommand('amiga-assembly.showVariableAsHexByteSigned', (variableInfo) => {
-        setDisplayFormat(variableInfo, NumberFormat.HEXADECIMAL_BYTE_SIGNED);
     });
     context.subscriptions.push(disposable);
 


### PR DESCRIPTION
Changed implementation for sign/size variants on register variables so we no longer need additional formats.