### PR TITLE
uae-dap v1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "amiga-assembly",
-	"version": "1.8.4",
+	"version": "1.8.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "amiga-assembly",
-			"version": "1.8.4",
+			"version": "1.8.5",
 			"license": "GNU General Public License v3.0",
 			"dependencies": {
 				"@vscode/debugadapter": "^1.64.0",
@@ -15,7 +15,7 @@
 				"axios": "^1.6.1",
 				"extract-zip": "^2.0.1",
 				"glob": "^10.3.10",
-				"uae-dap": "^1.0.5",
+				"uae-dap": "^1.0.6",
 				"uuid": "^9.0.1",
 				"winston": "^3.11.0",
 				"winston-transport": "^4.6.0"
@@ -4386,9 +4386,9 @@
 			}
 		},
 		"node_modules/uae-dap": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-1.0.5.tgz",
-			"integrity": "sha512-J02d7edx5G0fYEbydAcbToVsi3vzFzqM2HM/dj2YWo03oW7BscE+/ljxxn2wA4skgPcojfBOQIPDj15tATiOBQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-1.0.6.tgz",
+			"integrity": "sha512-GfEn07rY5ZWZdqoDTQlNgwPhMmcCMeRcw+aZ4b9xAO3GSvd2QiGv052qFLFira02Op1MNTnyndaD+SCvrswLcg==",
 			"dependencies": {
 				"@vscode/debugadapter": "^1.55.1",
 				"@vscode/debugprotocol": "^1.55.1",
@@ -8159,9 +8159,9 @@
 			"dev": true
 		},
 		"uae-dap": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-1.0.5.tgz",
-			"integrity": "sha512-J02d7edx5G0fYEbydAcbToVsi3vzFzqM2HM/dj2YWo03oW7BscE+/ljxxn2wA4skgPcojfBOQIPDj15tATiOBQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-1.0.6.tgz",
+			"integrity": "sha512-GfEn07rY5ZWZdqoDTQlNgwPhMmcCMeRcw+aZ4b9xAO3GSvd2QiGv052qFLFira02Op1MNTnyndaD+SCvrswLcg==",
 			"requires": {
 				"@vscode/debugadapter": "^1.55.1",
 				"@vscode/debugprotocol": "^1.55.1",

--- a/package.json
+++ b/package.json
@@ -1005,7 +1005,7 @@
 		"axios": "^1.6.1",
 		"extract-zip": "^2.0.1",
 		"glob": "^10.3.10",
-		"uae-dap": "^1.0.5",
+		"uae-dap": "^1.0.6",
 		"uuid": "^9.0.1",
 		"winston": "^3.11.0",
 		"winston-transport": "^4.6.0"


### PR DESCRIPTION
Fixes issue with `stopOnEntry` sometimes being labelled as an exception as discussed in #263.