### PR TITLE
Upgrade to uae-dap@1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"axios": "^1.6.1",
 				"extract-zip": "^2.0.1",
 				"glob": "^10.3.10",
-				"uae-dap": "^1.0.7",
+				"uae-dap": "^1.1.3",
 				"uuid": "^9.0.1",
 				"winston": "^3.11.0",
 				"winston-transport": "^4.6.0"
@@ -4385,9 +4385,9 @@
 			}
 		},
 		"node_modules/uae-dap": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-1.0.7.tgz",
-			"integrity": "sha512-dZxnQHyJs2Nan1PjKu1JOJoUB2q78iuMu28nL+PeLvzPe/hiAWVX4SxdGtm+Jx+yX0vm+oIuXAiYdghVG3+jaA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-1.1.3.tgz",
+			"integrity": "sha512-8gimx7LuksHLxWtPNAqbvXAfYzMf533knC8woYae16flTxmYXi5zMD8S7qnx49nryvrAdq7fNi/mD7IeKQwDPA==",
 			"dependencies": {
 				"@vscode/debugadapter": "^1.55.1",
 				"@vscode/debugprotocol": "^1.55.1",
@@ -4402,7 +4402,8 @@
 				"uae-dap": "cli.js"
 			},
 			"engines": {
-				"node": "*"
+				"node": "*",
+				"vscode": "^1.84.2"
 			}
 		},
 		"node_modules/uae-dap/node_modules/brace-expansion": {
@@ -8158,9 +8159,9 @@
 			"dev": true
 		},
 		"uae-dap": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-1.0.7.tgz",
-			"integrity": "sha512-dZxnQHyJs2Nan1PjKu1JOJoUB2q78iuMu28nL+PeLvzPe/hiAWVX4SxdGtm+Jx+yX0vm+oIuXAiYdghVG3+jaA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/uae-dap/-/uae-dap-1.1.3.tgz",
+			"integrity": "sha512-8gimx7LuksHLxWtPNAqbvXAfYzMf533knC8woYae16flTxmYXi5zMD8S7qnx49nryvrAdq7fNi/mD7IeKQwDPA==",
 			"requires": {
 				"@vscode/debugadapter": "^1.55.1",
 				"@vscode/debugprotocol": "^1.55.1",

--- a/package.json
+++ b/package.json
@@ -1005,7 +1005,7 @@
 		"axios": "^1.6.1",
 		"extract-zip": "^2.0.1",
 		"glob": "^10.3.10",
-		"uae-dap": "^1.0.7",
+		"uae-dap": "^1.1.3",
 		"uuid": "^9.0.1",
 		"winston": "^3.11.0",
 		"winston-transport": "^4.6.0"


### PR DESCRIPTION
Fixes #291

This also includes updated emulator binaries for WinUAE 5.1.0, and FS-UAE fork with backported changes up to this version too.