### PR TITLE
vasm console output skewed on macos

### DIFF
--- a/src/execHelper.ts
+++ b/src/execHelper.ts
@@ -84,6 +84,7 @@ export class ExecutorHelper {
                             text += stderr.toString()
                         }
                         if (logEmitter) {
+                            text = text.replace(/\n/g, '\r\n');
                             logEmitter.fire(text + '\r\n');
                         }
                         if (parser) {
@@ -142,7 +143,7 @@ export class ExecutorHelper {
                         }
                     }
                     if (stdout) {
-                        bufferOut += "\n" + stdout.toString();
+                        bufferOut += stdout.toString() + '\n';
                     }
                     resolve(bufferOut);
                 } catch (e) {


### PR DESCRIPTION
Hey guys!

Thanks for this impressive extension.

This patch fixes a very annoying bug on macOS:

Without patch
<img width="1371" alt="Screenshot 2024-11-11 at 20 46 51" src="https://github.com/user-attachments/assets/ad804db5-3728-477a-a9b2-4a93babc8925">

With patch:
<img width="711" alt="Screenshot 2024-11-11 at 20 46 12" src="https://github.com/user-attachments/assets/1f11033e-6ce4-428f-a252-dc7f6f3139dc">

Basically VSCode console seems to be confused by mix of CRLF and LF line endings.

I've tested this patch for around 3 weeks on my M1 Mac and it works good so far.
Haven't tested this fix on Windows.

Thanks.