### PR TITLE
🐛 fix bootblock creation

### DIFF
--- a/src/adf.ts
+++ b/src/adf.ts
@@ -128,7 +128,7 @@ export class ADFTools {
                 if (results?.[0]) {
                     const bootBlockDataFilename = results[0];
                     bootBlockFilename = bootBlockDataFilename.replace(".o", ".bb");
-                    const bootBlockDataFilenameUri = Uri.file(bootBlockDataFilename);
+                    const bootBlockDataFilenameUri = Uri.file(bootBlockFilename);
                     const bootBlockFile = new FileProxy(bootBlockDataFilenameUri);
                     // create the bootblock
                     try {
@@ -136,7 +136,7 @@ export class ADFTools {
                         logEmitter?.fire(`Adding bootblock to ADF\r\n`);
                         await this.writeBootBlockFile(Buffer.from(bootBlock), Uri.file(bootBlockFilename));
                     } catch (err) {
-                        throw new Error(`Error writing boot block '${bootBlockSourceFilename}'`);
+                        throw new Error(`Error writing boot block '${bootBlockSourceFilename}': ${err}`);
                     }
                 }
             } else {


### PR DESCRIPTION
I am not exactly sure why this happens for me. Maybe not too many people are using the boot feature? or maybe my setup is somehow broken?

It would try to open boot.o in the build folder even though the actual file that is created for me is "boot.bb".

This is the task I am using:

```
{
	"version": "2.0.0",
	"tasks": [
		{
			"type": "amigaassembly",
			"adfgenerator": {
				"ADFToolsParentDir": "${config:amiga-assembly.binDir}",
				"sourceRootDir": "uae/dh0",
				"outputADFFile": "./build/disk.adf",
				"includes": "**/*",
				"excludes": "**/.*",
				"adfCreateOptions": [
					"--label=CPRSHDWN"
				],
				"bootBlockSourceFile": "boot.s"
			},
			"problemMatcher": [],
			"label": "create adf"
		}
	]
}
```